### PR TITLE
add SLO TF files and README

### DIFF
--- a/dashboards-and-dashboard-groups/SLO-Error-Budget/README.md
+++ b/dashboards-and-dashboard-groups/SLO-Error-Budget/README.md
@@ -1,0 +1,100 @@
+# SLO / SLx Budgeting
+Included in this contribution are Terraform files to spin up an Error Budget / SLO integration with Charts / Dashboard and Alert for counting "Alert Minutes". Below you will find an extensive description of the SignalFlow and what it is doing.
+
+## Terraform Files
+
+To use these Terraform files please be sure to edit the following variables in `SLO-SLX.tf`
+```tf
+variable "slo_service_name" {
+    type = string
+    #Change this service name to an APM service name in your environment
+    default = "placeholder-name-add-your-own-name"
+}
+
+variable "detector_name" {
+   type = string
+   #Change this Detector Name as required
+   default = "SLO detector"
+}
+```
+1. `slo_service_name` is the APM service name of your APM service.
+2. `detector_name` is the name you would like to give your Alert Minutes detector.
+
+Then spin up the resources as you would anything else using the Signalfx Terraform Provider.
+*Note:* Make sure to have a `signalfx_auth_token`!
+
+## SignalFlow Details
+This example works off of the alerts() function to COUNT the number of alerts during a given period of time.
+
+This requires:
+1. An alert that only ever goes off for a minute at a time.
+    - During long stretches of time where alert would be triggered have it turn on/off every minute
+    - Likely use a rate for this alert (Error rate is most common)
+2. A charting method than can munge Alert data and use stats functions on it
+    - This includes a way to reset the “count” monthly/quarterly/weekly/etc (more on this later)
+
+### SignalFlow Alert Minutes Example:
+```
+filter_ = filter('sf_environment', '*') and filter('sf_service', 'adservice') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))
+
+A = data('spans.count', filter=filter_ and filter('sf_error', 'false'), rollup='rate').sum().publish(label='Success', enable=False)
+
+B = data('spans.count', filter=filter_, rollup='rate').sum().publish(label='All Traffic', enable=False)
+
+C = combine(100*((A if A is not None else 0)/B)).publish(label='Success Rate %')
+
+
+
+constant = const(30)
+
+detect(when(C < 98, duration("20s")), off=when(constant < 100, duration("35s")), mode='split').publish('Success Ratio Detector')
+```
+
+#### What are we doing here?
+1. Define a filter: We’re using APM data so this filter is mostly just targeting down to a specific service “adservice”
+2. Create our “Success Rate” (the inverse of error rate) so we can alert if we go below that number.
+    - A gets ONLY successful requests
+    - B gets ALL requests
+    - C makes the Success Rate
+3. Make our detector for Downtime Minutes (Minutes below Success Ratio threshold). This gets weird
+    - Make a constant value (could be anything). We use this to turn off the detector if it has been on for more than 50 seconds.
+    - Detector triggers when Success Rate (C) is below 95%
+      - Use the off= setting along with the mode=’split’ setting to reset the detector if two conditions are met. 
+        1. Detector is currently Triggered
+        2. Check if constant has been less than 100 for 50 seconds
+
+Essentially we have made an alert that will fire once every minute that the metric is breaching alertable threshold.
+
+### SignalFlow Charting Alert Minutes Against Monthly Budget:
+```
+## Chart based on detector firing
+A = alerts(detector_name='THIS IS MY DETECTOR NAME').count().publish(label='A', enable=False)
+alert_stream = (A).sum().publish(label="alert_stream")
+
+downtime = alert_stream.sum(cycle='month', partial_values=True).fill().publish(label="Downtime Minutes")
+
+## 99% uptime is roughly 438 minutes
+budgeted_minutes = const(438)
+
+Total = (budgeted_minutes - downtime).fill().publish(label="Available Budget")
+```
+
+#### What are we doing here?
+1. Define a metric stream from the Detector we created before.
+    - Take that alert stream and sum it. We want all the minutes!
+2. Create your “downtime minutes” stream 
+    - Sum the summed alert stream with a cycle= of month/week/etc and allow partial_values just in case.
+    - Use fill() to fill any empty data points with the last value
+3. Create a constant for the number of minutes in our “error budget” or “downtime budget”
+4. Create Total Available Budget
+    - Subtract downtime stream from budgeted minutes constant value
+    - Use fill() to fill any empty data points with the last value
+
+
+
+
+## Notes:
+Setting up Downtime Minutes alerts can be fiddly. 
+  - Duration to trigger and Duration to reset in the alert for Alert Minutes are codependent variables. Changing one requires changing the other.
+    - I.E. Alert if value below X for 20 seconds requires off= setting to be ~30 seconds
+  - This can be a point of argument from teams that their alert “only breached for 20 seconds out of the minute!” or similar.    

--- a/dashboards-and-dashboard-groups/SLO-Error-Budget/SLO-SLx.tf
+++ b/dashboards-and-dashboard-groups/SLO-Error-Budget/SLO-SLx.tf
@@ -1,0 +1,571 @@
+variable "slo_service_name" {
+    type = string
+    #Change this service name to an APM service name in your environment
+    default = "placeholder-name-add-your-own-name"
+}
+
+variable "detector_name" {
+   type = string
+   #Change this Detector Name as required
+   default = "SLO detector"
+}
+
+## Create detector to count downtime minutes
+resource "signalfx_detector" "slo_downtime_minutes" {
+
+  name        = "${var.slo_service_name} ${var.detector_name}"
+  description = "SLx detector based on successful traffic"
+  max_delay   = 30
+  tags        = ["SLO", "dev"]
+
+  ## Note that if you use these features, you must use a user's
+  ## admin key to authenticate the provider, lest Terraform not be able
+  ## to modify the detector in the future!
+
+  # authorized_writer_teams = [signalfx_team.mycoolteam.id]
+  # authorized_writer_users = ["abc123"]
+
+  program_text = <<-EOF
+        filter_ = filter('sf_environment', '*') and filter('sf_service', '${var.slo_service_name}') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))
+        A = data('spans.count', filter=filter_ and filter('sf_error', 'false'), rollup='rate').sum().publish(label='Success', enable=False)
+        B = data('spans.count', filter=filter_, rollup='rate').sum().publish(label='All Traffic', enable=False)
+        C = combine(100*((A if A is not None else 0)/B)).publish(label='Success Rate %')
+        
+        constant = const(30)
+
+        ### Force detector to retrigger ever minute when in a breaching state.
+        ### This gives us "downtime mintues"
+        detect(when(C < 99, duration("30s")), off=when(constant < 100, duration("20s")), mode='split').publish('Success Ratio Detector')
+    EOF
+
+  rule {
+    description   = "Successful traffic < 99 (downtime minutes)"
+    severity      = "Warning"
+    detect_label  = "Success Ratio Detector"
+    notifications = []
+  }    
+
+}
+
+
+### Create a Dashboard Group for our Dashboards
+resource "signalfx_dashboard_group" "slo_dashboard_group" {
+  name        = "SLO / SLx Dashboards"
+  description = "SLO / SLx Level Dashboards"
+
+  ### Note that if you use these features, you must use a user's
+  ### admin key to authenticate the provider, lest Terraform not be able
+  ### to modify the dashboard group in the future!
+  #authorized_writer_teams = [signalfx_team.mycoolteam.id]
+  #authorized_writer_users = ["abc123"]
+}
+
+
+# signalfx_time_chart.SLO-SLx-Investigation_0:
+resource "signalfx_time_chart" "SLO-SLx-Investigation_0" {
+    axes_include_zero         = false
+    axes_precision            = 0
+    color_by                  = "Dimension"
+    description               = "Downtime minutes over 31 day cycle"
+    disable_sampling          = false
+    max_delay                 = 0
+    minimum_resolution        = 0
+    name                      = "Downtime Minutes (SLO)"
+    on_chart_legend_dimension = "plot_label"
+    plot_type                 = "ColumnChart"
+    program_text              = <<-EOF
+        A = alerts(detector_name='${var.slo_service_name} ${var.detector_name}').count().publish(label='A', enable=False)
+        alert_stream = (A).sum().fill(0).publish(label="alert_stream")
+        
+        downtime = (alert_stream).sum(cycle='month', cycle_start='1d', partial_values=True).fill().publish(label="Downtime Minutes")
+    EOF
+    show_data_markers         = true
+    show_event_lines          = true
+    stacked                   = false
+    time_range                = 900
+    unit_prefix               = "Metric"
+
+    event_options {
+        display_name = "${var.slo_service_name} ${var.detector_name}"
+        label        = "A"
+    }
+
+    histogram_options {
+        color_theme = "red"
+    }
+
+    viz_options {
+        axis         = "left"
+        display_name = "Downtime Minutes"
+        label        = "Downtime Minutes"
+    }
+    viz_options {
+        axis         = "left"
+        color        = "green"
+        display_name = "alert_stream"
+        label        = "alert_stream"
+        plot_type    = "ColumnChart"
+    }
+}
+# signalfx_single_value_chart.SLO-SLx-Investigation_1:
+resource "signalfx_single_value_chart" "SLO-SLx-Investigation_1" {
+    color_by                = "Scale"
+    description             = "99.99% , 99.5% , and 99% availability in minutes (1month)"
+    is_timestamp_hidden     = false
+    max_delay               = 0
+    max_precision           = 0
+    name                    = "Downtime Minutes (SLO) 1month"
+    program_text            = <<-EOF
+        A = alerts(detector_name='${var.slo_service_name} ${var.detector_name}').count().publish(label='A', enable=False)
+        alert_stream = (A).sum().fill(0).publish(label="alert_stream", enable=False)
+        
+        
+        downtime = (alert_stream).sum(cycle='month', cycle_start='1d', partial_values=True).fill().publish(label="Downtime Minutes")
+        
+        ## Break points on the radial above are 99.99% , 99.5% , and 99% availability in minutes
+    EOF
+    secondary_visualization = "Radial"
+    show_spark_line         = false
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "lime_green"
+        gt    = 340282346638528860000000000000000000000
+        gte   = 0
+        lt    = 340282346638528860000000000000000000000
+        lte   = 44
+    }
+    color_scale {
+        color = "red"
+        gt    = 220
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 438
+    }
+    color_scale {
+        color = "vivid_yellow"
+        gt    = 44
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 220
+    }
+
+    viz_options {
+        display_name = "Downtime Minutes"
+        label        = "Downtime Minutes"
+    }
+    viz_options {
+        color        = "green"
+        display_name = "alert_stream"
+        label        = "alert_stream"
+    }
+}
+# signalfx_time_chart.SLO-SLx-Investigation_2:
+resource "signalfx_time_chart" "SLO-SLx-Investigation_2" {
+    axes_include_zero         = false
+    axes_precision            = 0
+    color_by                  = "Dimension"
+    description               = "Downtime Minutes Budget over 31 day cycle"
+    disable_sampling          = false
+    max_delay                 = 0
+    minimum_resolution        = 0
+    name                      = "Downtime Budget (SLO)"
+    on_chart_legend_dimension = "plot_label"
+    plot_type                 = "ColumnChart"
+    program_text              = <<-EOF
+        A = alerts(detector_name='${var.slo_service_name} ${var.detector_name}').count().publish(label='A', enable=False)
+        alert_stream = (A).sum().fill(0).publish(label="alert_stream")
+        
+        downtime = (alert_stream).sum(cycle='month', cycle_start='1d', partial_values=True).fill().publish(label="Downtime Minutes", enable=False)
+        
+        ## 99% uptime is roughly 438 minutes
+        budgeted_minutes = const(438)
+        
+        Total = (budgeted_minutes - downtime).fill().publish(label="Available Budget")
+    EOF
+    show_data_markers         = true
+    show_event_lines          = true
+    stacked                   = false
+    time_range                = 900
+    unit_prefix               = "Metric"
+
+    event_options {
+        display_name = "${var.slo_service_name} ${var.detector_name}"
+        label        = "A"
+    }
+
+    histogram_options {
+        color_theme = "red"
+    }
+
+    viz_options {
+        axis         = "left"
+        display_name = "Available Budget"
+        label        = "Available Budget"
+    }
+    viz_options {
+        axis         = "left"
+        display_name = "Downtime Minutes"
+        label        = "Downtime Minutes"
+    }
+    viz_options {
+        axis         = "left"
+        color        = "green"
+        display_name = "alert_stream"
+        label        = "alert_stream"
+        plot_type    = "ColumnChart"
+    }
+}
+# signalfx_single_value_chart.SLO-SLx-Investigation_3:
+resource "signalfx_single_value_chart" "SLO-SLx-Investigation_3" {
+    color_by                = "Scale"
+    description             = "Downtime Budget Remaining (1month)"
+    is_timestamp_hidden     = false
+    max_delay               = 0
+    max_precision           = 0
+    name                    = "Downtime Budget Remaining (SLO) 1month"
+    program_text            = <<-EOF
+        A = alerts(detector_name='${var.slo_service_name} ${var.detector_name}').count().publish(label='A', enable=False)
+        alert_stream = (A).sum().fill(0).publish(label="alert_stream", enable=False)
+        
+        downtime = (alert_stream).sum(cycle='month', cycle_start='1d', partial_values=True).fill().publish(label="Downtime Minutes", enable=False)
+                
+        ## 99% uptime is roughly 438 minutes
+        budgeted_minutes = const(438)
+                
+        Total = (budgeted_minutes - downtime).fill().publish(label="Available Budget")
+
+    EOF
+    secondary_visualization = "Linear"
+    show_spark_line         = false
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "lime_green"
+        gt    = 395
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 438
+    }
+    color_scale {
+        color = "red"
+        gt    = 340282346638528860000000000000000000000
+        gte   = 0
+        lt    = 340282346638528860000000000000000000000
+        lte   = 219
+    }
+    color_scale {
+        color = "vivid_yellow"
+        gt    = 219
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 395
+    }
+
+    viz_options {
+        display_name = "A"
+        label        = "A"
+    }
+    viz_options {
+        display_name = "Available Budget"
+        label        = "Available Budget"
+    }
+    viz_options {
+        display_name = "Downtime Minutes"
+        label        = "Downtime Minutes"
+    }
+    viz_options {
+        color        = "green"
+        display_name = "alert_stream"
+        label        = "alert_stream"
+    }
+}
+# signalfx_time_chart.SLO-SLx-Investigation_4:
+resource "signalfx_time_chart" "SLO-SLx-Investigation_4" {
+    axes_include_zero         = false
+    axes_precision            = 0
+    color_by                  = "Dimension"
+    description               = "Weekly Downtime minutes over 7 day cycle"
+    disable_sampling          = false
+    max_delay                 = 0
+    minimum_resolution        = 0
+    name                      = "Weekly Downtime Minutes (SLO)"
+    on_chart_legend_dimension = "plot_label"
+    plot_type                 = "ColumnChart"
+    program_text              = <<-EOF
+        A = alerts(detector_name='${var.slo_service_name} ${var.detector_name}').count().publish(label='A', enable=False)
+        alert_stream = (A).sum().fill(0).publish(label="alert_stream")
+        
+        downtime = (alert_stream).sum(cycle='week', cycle_start='Monday', partial_values=True).fill().publish(label="Downtime Minutes")
+    EOF
+    show_data_markers         = true
+    show_event_lines          = true
+    stacked                   = false
+    time_range                = 900
+    unit_prefix               = "Metric"
+
+    event_options {
+        display_name = "${var.slo_service_name} ${var.detector_name}"
+        label        = "A"
+    }
+
+    histogram_options {
+        color_theme = "red"
+    }
+
+    viz_options {
+        axis         = "left"
+        color        = "brown"
+        display_name = "alert_stream"
+        label        = "alert_stream"
+        plot_type    = "ColumnChart"
+    }
+    viz_options {
+        axis         = "left"
+        color        = "iris"
+        display_name = "Downtime Minutes"
+        label        = "Downtime Minutes"
+    }
+}
+# signalfx_single_value_chart.SLO-SLx-Investigation_5:
+resource "signalfx_single_value_chart" "SLO-SLx-Investigation_5" {
+    color_by                = "Scale"
+    description             = "99.99% , 99.5% , and 99% availability in minutes (1week)"
+    is_timestamp_hidden     = false
+    max_delay               = 0
+    max_precision           = 0
+    name                    = "Weekly Downtime Minutes (SLO) 1week"
+    program_text            = <<-EOF
+        A = alerts(detector_name='${var.slo_service_name} ${var.detector_name}').count().publish(label='A', enable=False)
+        alert_stream = (A).sum().fill(0).publish(label="alert_stream", enable=False)
+        
+        downtime = (alert_stream).sum(cycle='week', cycle_start='Monday', partial_values=True).fill().publish(label="Downtime Minutes")
+        
+        ## Break points on the radial above are 99.99% , 99.5% , and 99% availability in minutes
+    EOF
+    secondary_visualization = "Radial"
+    show_spark_line         = false
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "lime_green"
+        gt    = 340282346638528860000000000000000000000
+        gte   = 0
+        lt    = 340282346638528860000000000000000000000
+        lte   = 22
+    }
+    color_scale {
+        color = "red"
+        gt    = 55
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 101
+    }
+    color_scale {
+        color = "vivid_yellow"
+        gt    = 22
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 55
+    }
+
+    viz_options {
+        display_name = "A"
+        label        = "A"
+    }
+    viz_options {
+        display_name = "Downtime Minutes"
+        label        = "Downtime Minutes"
+    }
+    viz_options {
+        color        = "green"
+        display_name = "alert_stream"
+        label        = "alert_stream"
+    }
+}
+# signalfx_time_chart.SLO-SLx-Investigation_6:
+resource "signalfx_time_chart" "SLO-SLx-Investigation_6" {
+    axes_include_zero         = false
+    axes_precision            = 0
+    color_by                  = "Dimension"
+    description               = "Downtime Minutes Budget over 7 day cycle"
+    disable_sampling          = false
+    max_delay                 = 0
+    minimum_resolution        = 0
+    name                      = "Weekly Downtime Budget (SLO)"
+    on_chart_legend_dimension = "plot_label"
+    plot_type                 = "ColumnChart"
+    program_text              = <<-EOF
+        A = alerts(detector_name='${var.slo_service_name} ${var.detector_name}').count().publish(label='A', enable=False)
+        alert_stream = (A).sum().fill(0).publish(label="alert_stream")
+        
+        downtime = (alert_stream).sum(cycle='week', cycle_start='Monday', partial_values=True).fill().publish(label="Downtime Minutes", enable=False)
+        
+        ## 99% uptime is roughly 101 minutes
+        budgeted_minutes = const(101)
+        
+        Total = (budgeted_minutes - downtime).fill().publish(label="Available Budget")
+    EOF
+    show_data_markers         = true
+    show_event_lines          = true
+    stacked                   = false
+    time_range                = 900
+    unit_prefix               = "Metric"
+
+    event_options {
+        display_name = "${var.slo_service_name} ${var.detector_name}"
+        label        = "A"
+    }
+
+    histogram_options {
+        color_theme = "red"
+    }
+
+    viz_options {
+        axis         = "left"
+        display_name = "Downtime Minutes"
+        label        = "Downtime Minutes"
+    }
+    viz_options {
+        axis         = "left"
+        color        = "brown"
+        display_name = "alert_stream"
+        label        = "alert_stream"
+        plot_type    = "ColumnChart"
+    }
+    viz_options {
+        axis         = "left"
+        color        = "navy"
+        display_name = "Available Budget"
+        label        = "Available Budget"
+    }
+}
+# signalfx_single_value_chart.SLO-SLx-Investigation_7:
+resource "signalfx_single_value_chart" "SLO-SLx-Investigation_7" {
+    color_by                = "Scale"
+    description             = "Downtime Budget Remaining (1week)"
+    is_timestamp_hidden     = false
+    max_delay               = 0
+    max_precision           = 0
+    name                    = "Weekly Downtime Budget Remaining (SLO) 1week"
+    program_text            = <<-EOF
+        A = alerts(detector_name='${var.slo_service_name} ${var.detector_name}').count().publish(label='A', enable=False)
+        alert_stream = (A).sum().fill(0).publish(label="alert_stream", enable=False)
+        
+        downtime = (alert_stream).sum(cycle='week', cycle_start='Monday', partial_values=True).fill().publish(label="Downtime Minutes", enable=False)
+        
+        ## 99% uptime is roughly 101 minutes
+        budgeted_minutes = const(101)
+        
+        Total = (budgeted_minutes - downtime).fill().publish(label="Available Budget")
+    EOF
+    secondary_visualization = "Linear"
+    show_spark_line         = false
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "lime_green"
+        gt    = 55
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 101
+    }
+    color_scale {
+        color = "vivid_yellow"
+        gt    = 22
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 55
+    }
+    color_scale {
+        color = "red"
+        gt    = 340282346638528860000000000000000000000
+        gte   = 0
+        lt    = 340282346638528860000000000000000000000
+        lte   = 22
+    }
+
+    viz_options {
+        display_name = "A"
+        label        = "A"
+    }
+    viz_options {
+        display_name = "Available Budget"
+        label        = "Available Budget"
+    }
+    viz_options {
+        display_name = "Downtime Minutes"
+        label        = "Downtime Minutes"
+    }
+    viz_options {
+        color        = "green"
+        display_name = "alert_stream"
+        label        = "alert_stream"
+    }
+}
+# signalfx_dashboard.SLO-SLx-Investigation:
+resource "signalfx_dashboard" "SLO-SLx-Investigation" {
+    charts_resolution = "default"
+    dashboard_group   = signalfx_dashboard_group.slo_dashboard_group.id
+    description       = "Default dashboard."
+    name              = "${var.slo_service_name} SLO/SLx Investigation Dashboard"
+    time_range        = "-31d"
+
+    chart {
+        chart_id = signalfx_time_chart.SLO-SLx-Investigation_0.id
+        column   = 0
+        height   = 2
+        row      = 0
+        width    = 9
+    }
+    chart {
+        chart_id = signalfx_time_chart.SLO-SLx-Investigation_2.id
+        column   = 0
+        height   = 2
+        row      = 2
+        width    = 9
+    }
+    chart {
+        chart_id = signalfx_single_value_chart.SLO-SLx-Investigation_1.id
+        column   = 9
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_single_value_chart.SLO-SLx-Investigation_3.id
+        column   = 9
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_time_chart.SLO-SLx-Investigation_6.id
+        column   = 0
+        height   = 2
+        row      = 6
+        width    = 9
+    }
+    chart {
+        chart_id = signalfx_time_chart.SLO-SLx-Investigation_4.id
+        column   = 0
+        height   = 2
+        row      = 4
+        width    = 9
+    }
+    chart {
+        chart_id = signalfx_single_value_chart.SLO-SLx-Investigation_7.id
+        column   = 9
+        height   = 2
+        row      = 6
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_single_value_chart.SLO-SLx-Investigation_5.id
+        column   = 9
+        height   = 2
+        row      = 4
+        width    = 3
+    }
+
+}

--- a/dashboards-and-dashboard-groups/SLO-Error-Budget/main.tf
+++ b/dashboards-and-dashboard-groups/SLO-Error-Budget/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source = "splunk-terraform/signalfx"
+      version = ">=6.13.1"
+    }
+  }
+}
+
+variable "signalfx_auth_token" {
+   type=string
+}
+
+provider "signalfx" {
+  auth_token = "${var.signalfx_auth_token}"
+  # If your organization uses a different realm
+  # api_url = "https://api.us2.signalfx.com"
+  # If your organization uses a custom URL
+  # custom_app_url = "https://myorg.signalfx.com"
+}


### PR DESCRIPTION
Adds Terraform files for easily spinning up an SLO/SLx Error Budgeting dashboard utilizing Alert Minutes.
1. This is an Example of Advanced SignalFlow usage
2. Terraform files spin up an alert to track alert minutes and charts+dashboard to track those alert minutes against an error budget for Splunk Observability APM services.
