### PR TITLE
Minor tweaks to executive level dashboard for log observer

### DIFF
--- a/dashboards-and-dashboard-groups/executive-dashboards/Logs-Exec.tf
+++ b/dashboards-and-dashboard-groups/executive-dashboards/Logs-Exec.tf
@@ -70,7 +70,7 @@ resource "signalfx_dashboard" "Logs-Exec" {
 # signalfx_list_chart.Logs-Exec_0:
 resource "signalfx_list_chart" "Logs-Exec_0" {
     color_by                = "Dimension"
-    description             = "Logs - Logs Received per Day by Token Top 5 (7 day avg)"
+    description             = "Logs Received per Day by Token Top 5 (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -127,7 +127,7 @@ resource "signalfx_list_chart" "Logs-Exec_0" {
 # signalfx_list_chart.Logs-Exec_1:
 resource "signalfx_list_chart" "Logs-Exec_1" {
     color_by                = "Dimension"
-    description             = "Logs Logs Received per Day by Token Top & Bottom 5 (12 week comparison)"
+    description             = "Logs Received per Day by Token Top & Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -207,7 +207,7 @@ resource "signalfx_list_chart" "Logs-Exec_1" {
 # signalfx_list_chart.Logs-Exec_2:
 resource "signalfx_list_chart" "Logs-Exec_2" {
     color_by                = "Dimension"
-    description             = "Logs - Profiling Logs Received per Day by Token Top 5 (7 day avg)"
+    description             = "Profiling Logs Received per Day by Token Top 5 (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -346,8 +346,9 @@ resource "signalfx_list_chart" "Logs-Exec_3" {
 resource "signalfx_text_chart" "Logs-Exec_4" {
     markdown = <<-EOF
         ###_Log Observer Events charts require this query_
+        ##### Note: Logs ingested with Log Observer Connect will need to be metricized in Splunk Cloud
         
-        Setup Log Pipeline Management Metric:
+        **Setup Log Pipeline Management Metric:**
         ##### -Matching Condition: Match All
         ##### -Operation: count
         ##### -Dimensions: ["severity","deployment.environment"]
@@ -361,7 +362,7 @@ resource "signalfx_text_chart" "Logs-Exec_4" {
 # signalfx_list_chart.Logs-Exec_5:
 resource "signalfx_list_chart" "Logs-Exec_5" {
     color_by                = "Dimension"
-    description             = "Logs - Events per Day by Log Level (7 day avg)"
+    description             = "Events per Day by Log Level (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -498,7 +499,7 @@ resource "signalfx_time_chart" "Logs-Exec_7" {
     axes_include_zero  = false
     axes_precision     = 0
     color_by           = "Dimension"
-    description        = "Logs - Events Received per Day by Log Level (7 day avg)"
+    description        = "Events Received per Day by Log Level (7 day avg)"
     disable_sampling   = false
     max_delay          = 0
     minimum_resolution = 0

--- a/dashboards-and-dashboard-groups/executive-dashboards/README.md
+++ b/dashboards-and-dashboard-groups/executive-dashboards/README.md
@@ -14,6 +14,8 @@ Executive Dashboards in this group are focused on high level comparisons over ti
 
 
 ## Log Observer Severity Metric
+Note: When using Log Observer Connect this metric will need to be metricized in Splunk Cloud.
+
 This metric enables visualizing log observer ingest by severity/log level.
 ```
 Matching Condition: Match All

--- a/dashboards-and-dashboard-groups/snowflakedb/README.md
+++ b/dashboards-and-dashboard-groups/snowflakedb/README.md
@@ -10,22 +10,6 @@ This folder contains a Dashboard Group and individual Dashboards for Snowflake a
 2. [`splunk-otel-collector.conf`](./Configuration/splunk-otel-collector.conf) Contains referenced variables like snowflake username / password, and Splunk Observability token, etc
 3. [`snowflake-metrics.yaml`](./Configuration/snowflake-metrics.yaml) Contains SQL queries and mappings for our Splunk Observability metrics and dimensions pulling metrics from the Snowflake `SNOWFLAKE/ACCOUNT_USAGE` internal view.
 
-### Log Observer Severity Metric
-This Log Observer metric enables visualizing Log Observer ingest by severity/log level.  
-```
-Matching Condition: Match All
-
-Operation: count
-
-Dimensions: ["severity","deployment.environment"]
-(Replace "deployment.environment" with your environment dimension)
-
-Field: null
-
-Metric Name: logs.events.count
-
-```
-
 ## Sections
 ### Snowflake Home (overview):
   - General overview of Snowflake activity including Queries, errors, storage, user, login, credit counts, etc


### PR DESCRIPTION
Clarifies that Log Observer Connect users will need to create their log severity metric in Splunk Cloud.
- In README
- In Dashboard/Charts

Also removes an erroneous bit from the Snowflake docs
