### PR TITLE
add Exec dashboards to terraform jumpstart materials

### DIFF
--- a/integration-examples/terraform-jumpstart/main.tf
+++ b/integration-examples/terraform-jumpstart/main.tf
@@ -59,3 +59,8 @@ module "rum_and_synthetics_dashboard" {
   source     = "./modules/dashboards/rum_and_synthetics"
   o11y_prefix = var.o11y_prefix
 }
+
+module "executive-dashboards" {
+  source     = "./modules/dashboards/executive-dashboards"
+  o11y_prefix = var.o11y_prefix
+}

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/APM_IMM-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/APM_IMM-Exec.tf
@@ -1,0 +1,830 @@
+# signalfx_dashboard.APM_IMM-Exec:
+resource "signalfx_dashboard" "APM_IMM-Exec" {
+    charts_resolution = "default"
+    dashboard_group   = signalfx_dashboard_group.exec_dashboard_group.id
+    name              = "APM / IMM - Exec"
+    time_range        = "-12w"
+
+    chart {
+        chart_id = signalfx_list_chart.APM_IMM-Exec_2.id
+        column   = 6
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.APM_IMM-Exec_7.id
+        column   = 9
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.APM_IMM-Exec_0.id
+        column   = 0
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.APM_IMM-Exec_5.id
+        column   = 3
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.APM_IMM-Exec_3.id
+        column   = 9
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.APM_IMM-Exec_4.id
+        column   = 0
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.APM_IMM-Exec_6.id
+        column   = 6
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.APM_IMM-Exec_1.id
+        column   = 3
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+
+    variable {
+        alias                  = "Environment"
+        apply_if_exist         = false
+        description            = "APM Environment Name"
+        property               = "sf_environment"
+        replace_only           = true
+        restricted_suggestions = false
+        value_required         = true
+        values                 = [
+            "*",
+        ]
+        values_suggested       = []
+    }
+    variable {
+        alias                  = "Service"
+        apply_if_exist         = false
+        description            = "APM Service Name"
+        property               = "sf_service"
+        replace_only           = true
+        restricted_suggestions = false
+        value_required         = true
+        values                 = [
+            "*",
+        ]
+        values_suggested       = []
+    }
+}
+
+
+# signalfx_list_chart.APM_IMM-Exec_0:
+resource "signalfx_list_chart" "APM_IMM-Exec_0" {
+    color_by                = "Scale"
+    description             = "Traffic Change Top and Bottom 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Request rate 12 week comparison"
+    program_text            = <<-EOF
+        A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate').sum(by=['sf_service']).mean(over='7d').publish(label='A', enable=False)
+        B = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate').sum(by=['sf_service']).timeshift('12w').mean(over='7d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['sf_service']).mean(over='7d').top(count=5).publish(label='C')
+        D = (((A-B)/B)*100).mean(by=['sf_service']).mean(over='7d').bottom(count=5).publish(label='D')
+    EOF
+    refresh_interval        = 3600
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "lime_green"
+        gt    = 340282346638528860000000000000000000000
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 0
+    }
+    color_scale {
+        color = "red"
+        gt    = 0
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 340282346638528860000000000000000000000
+    }
+
+    viz_options {
+        color        = "brown"
+        display_name = "% Change"
+        label        = "D"
+        value_suffix = "%"
+    }
+    viz_options {
+        color        = "gray"
+        display_name = "% Change"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        color        = "lilac"
+        display_name = "Requests"
+        label        = "A"
+        value_suffix = "requests/s"
+    }
+    viz_options {
+        color        = "lilac"
+        display_name = "Requests(-4w)"
+        label        = "B"
+        value_suffix = "requests/s"
+    }
+}
+# signalfx_list_chart.APM_IMM-Exec_1:
+resource "signalfx_list_chart" "APM_IMM-Exec_1" {
+    color_by                = "Scale"
+    description             = "Requests compared"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Total Request (4 & 12 week comparisons)"
+    program_text            = <<-EOF
+        C = data('service.request.count', filter=(not filter('sf_dimensionalized', '*')) and filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate').sum(over='1d').sum().publish(label='C')
+        D = data('service.request.count', filter=(not filter('sf_dimensionalized', '*')) and filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate').sum(over='1d').sum().timeshift('4w').publish(label='D', enable=False)
+        E = data('service.request.count', filter=(not filter('sf_dimensionalized', '*')) and filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate').sum(over='1d').sum().timeshift('12w').publish(label='E', enable=False)
+        F = (((C-D)/C)*100).publish(label='F')
+        G = (((C-E)/C)*100).publish(label='G')
+    EOF
+    secondary_visualization = "Radial"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "aquamarine"
+        gt    = 340282346638528860000000000000000000000
+        gte   = -100
+        lt    = 340282346638528860000000000000000000000
+        lte   = 0
+    }
+    color_scale {
+        color = "gray"
+        gt    = 0
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 100
+    }
+
+    viz_options {
+        display_name = "% 12 week Change"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "% 4 week Change"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        color        = "lilac"
+        display_name = "-12w"
+        label        = "E"
+        value_suffix = "requests/s"
+    }
+    viz_options {
+        color        = "lilac"
+        display_name = "-4w"
+        label        = "D"
+        value_suffix = "requests/s"
+    }
+    viz_options {
+        color        = "lilac"
+        display_name = "Today"
+        label        = "C"
+        value_suffix = "requests/s"
+    }
+}
+# signalfx_list_chart.APM_IMM-Exec_2:
+resource "signalfx_list_chart" "APM_IMM-Exec_2" {
+    color_by                = "Scale"
+    description             = "Latency (P90) Top and Bottom 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Latency (P90) 12 week comparison"
+    program_text            = <<-EOF
+        def weighted_duration(base, p, filter_, groupby):
+            error_durations     = data(base + '.duration.ns.' + p, filter=filter_ and filter('sf_error', 'true'),  rollup='max').mean(by=groupby, allow_missing=['sf_httpMethod'])
+            non_error_durations = data(base + '.duration.ns.' + p, filter=filter_ and filter('sf_error', 'false'), rollup='max').mean(by=groupby, allow_missing=['sf_httpMethod'])
+        
+            error_counts     = data(base + '.count', filter=filter_ and filter('sf_error', 'true'),  rollup='sum').sum(by=groupby, allow_missing=['sf_httpMethod'])
+            non_error_counts = data(base + '.count', filter=filter_ and filter('sf_error', 'false'), rollup='sum').sum(by=groupby, allow_missing=['sf_httpMethod'])
+        
+            error_weight     = (error_durations * error_counts).sum(over='1m')
+            non_error_weight = (non_error_durations * non_error_counts).sum(over='1m')
+        
+            total_weight = combine((error_weight if error_weight is not None else 0) + (non_error_weight if non_error_weight is not None else 0))
+            total = combine((error_counts if error_counts is not None else 0) + (non_error_counts if non_error_counts is not None else 0)).sum(over='1m')
+            return (total_weight / total)
+        
+        filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and not filter('sf_dimensionalized', '*')
+        groupby = ['sf_service', 'sf_environment']
+        weighted_duration('service.request', 'p90', filter_, groupby).mean()
+        
+        A = weighted_duration('service.request', 'p90', filter_, groupby).mean(by=['sf_service']).mean(over='7d').publish(label='A', enable=False)
+        B = weighted_duration('service.request', 'p90', filter_, groupby).mean(by=['sf_service']).timeshift('12w').mean(over='7d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['sf_service']).mean(over='7d').top(count=5).publish(label='C')
+        D = (((A-B)/B)*100).mean(by=['sf_service']).mean(over='7d').bottom(count=5).publish(label='D')
+    EOF
+    refresh_interval        = 3600
+    secondary_visualization = "None"
+    sort_by                 = "+value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "lime_green"
+        gt    = 0
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 340282346638528860000000000000000000000
+    }
+    color_scale {
+        color = "red"
+        gt    = 340282346638528860000000000000000000000
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 0
+    }
+
+    viz_options {
+        color        = "aquamarine"
+        display_name = "% Change"
+        label        = "D"
+        value_suffix = "%"
+    }
+    viz_options {
+        color        = "gray"
+        display_name = "% Change"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        color        = "lilac"
+        display_name = "Requests"
+        label        = "A"
+        value_suffix = "requests/s"
+    }
+    viz_options {
+        color        = "lilac"
+        display_name = "Requests(-4w)"
+        label        = "B"
+        value_suffix = "requests/s"
+    }
+}
+# signalfx_list_chart.APM_IMM-Exec_3:
+resource "signalfx_list_chart" "APM_IMM-Exec_3" {
+    color_by                = "Scale"
+    description             = "Latency (P90) Compared"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Latency (P90) (4 & 12 week comparisons)"
+    program_text            = <<-EOF
+        def weighted_duration(base, p, filter_, groupby):
+            error_durations     = data(base + '.duration.ns.' + p, filter=filter_ and filter('sf_error', 'true'),  rollup='max').mean(by=groupby, allow_missing=['sf_httpMethod'])
+            non_error_durations = data(base + '.duration.ns.' + p, filter=filter_ and filter('sf_error', 'false'), rollup='max').mean(by=groupby, allow_missing=['sf_httpMethod'])
+        
+            error_counts     = data(base + '.count', filter=filter_ and filter('sf_error', 'true'),  rollup='sum').sum(by=groupby, allow_missing=['sf_httpMethod'])
+            non_error_counts = data(base + '.count', filter=filter_ and filter('sf_error', 'false'), rollup='sum').sum(by=groupby, allow_missing=['sf_httpMethod'])
+        
+            error_weight     = (error_durations * error_counts).sum(over='1m')
+            non_error_weight = (non_error_durations * non_error_counts).sum(over='1m')
+        
+            total_weight = combine((error_weight if error_weight is not None else 0) + (non_error_weight if non_error_weight is not None else 0))
+            total = combine((error_counts if error_counts is not None else 0) + (non_error_counts if non_error_counts is not None else 0)).sum(over='1m')
+            return (total_weight / total)
+        
+        filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and not filter('sf_dimensionalized', '*')
+        groupby = ['sf_service', 'sf_environment']
+        weighted_duration('service.request', 'p90', filter_, groupby)
+        
+        C = weighted_duration('service.request', 'p90', filter_, groupby).mean(over='1d').mean().scale(0.00000001).publish(label='C')
+        D = weighted_duration('service.request', 'p90', filter_, groupby).mean(over='1d').mean().scale(0.00000001).timeshift('4w').publish(label='D', enable=False)
+        E = weighted_duration('service.request', 'p90', filter_, groupby).mean(over='1d').mean().scale(0.00000001).timeshift('12w').publish(label='E', enable=False)
+        F = (((C-D)/C)*100).publish(label='F')
+        G = (((C-E)/C)*100).publish(label='G')
+    EOF
+    secondary_visualization = "Radial"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "aquamarine"
+        gt    = 340282346638528860000000000000000000000
+        gte   = -100
+        lt    = 340282346638528860000000000000000000000
+        lte   = 0
+    }
+    color_scale {
+        color = "gray"
+        gt    = 0
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 100
+    }
+
+    viz_options {
+        display_name = "% 12 week Change"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "% 4 week Change"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        color        = "lilac"
+        display_name = "-12w"
+        label        = "E"
+        value_suffix = "requests/s"
+    }
+    viz_options {
+        color        = "lilac"
+        display_name = "-4w"
+        label        = "D"
+        value_suffix = "requests/s"
+    }
+    viz_options {
+        color        = "lilac"
+        display_name = "Today"
+        label        = "C"
+        value_unit   = "Millisecond"
+    }
+}
+# signalfx_list_chart.APM_IMM-Exec_4:
+resource "signalfx_list_chart" "APM_IMM-Exec_4" {
+    color_by                = "Scale"
+    description             = "Error rate Top and Bottom 5 (12 week comparison)"
+    disable_sampling        = true
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Error rate 12 week comparison"
+    program_text            = <<-EOF
+        filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and (not filter('sf_dimensionalized', '*'))
+        A = data('service.request.count', filter=filter_ and filter('sf_error', 'true'), rollup='delta').sum(by=['sf_environment', 'sf_service']).mean(over='7d').publish(label='A', enable=False)
+        B = data('service.request.count', filter=filter_, rollup='delta').sum(by=['sf_environment', 'sf_service']).mean(over='7d').publish(label='B', enable=False)
+        C = combine(100*((A if A is not None else 0) / B)).publish(label='C', enable=False)
+        D = combine(100*((A if A is not None else 0) / B)).timeshift('12w').publish(label='D', enable=False)
+        
+        E = (((C-D)/D)*100).mean(by=['sf_service']).mean(over='7d').top(count=5).publish(label='% Change')
+        F = (((C-D)/D)*100).mean(by=['sf_service']).mean(over='7d').bottom(count=5).publish(label='% Change')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "+value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "lime_green"
+        gt    = 340282346638528860000000000000000000000
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 0
+    }
+    color_scale {
+        color = "red"
+        gt    = 0
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 340282346638528860000000000000000000000
+    }
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_service"
+    }
+
+    viz_options {
+        display_name = "% Change"
+        label        = "% Change"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+    }
+    viz_options {
+        display_name = "Errors"
+        label        = "A"
+    }
+    viz_options {
+        display_name = "Requests"
+        label        = "B"
+    }
+    viz_options {
+        color        = "pink"
+        display_name = "Error rate"
+        label        = "C"
+        value_suffix = "%"
+    }
+}
+# signalfx_list_chart.APM_IMM-Exec_5:
+resource "signalfx_list_chart" "APM_IMM-Exec_5" {
+    color_by                = "Scale"
+    description             = "Error rate compared"
+    disable_sampling        = true
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Error rate (4 & 12 week comparisons)"
+    program_text            = <<-EOF
+        filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and (not filter('sf_dimensionalized', '*'))
+        A = data('service.request.count', filter=filter_ and filter('sf_error', 'true'), rollup='delta').sum(by=['sf_environment', 'sf_service']).mean(over='1d').publish(label='A', enable=False)
+        B = data('service.request.count', filter=filter_, rollup='delta').sum(by=['sf_environment', 'sf_service']).mean(over='1d').publish(label='B', enable=False)
+        C = combine(100*((A if A is not None else 0) / B)).mean().publish(label='Today')
+        D = combine(100*((A if A is not None else 0) / B)).mean().timeshift('4w').publish(label='4w', enable=False)
+        E = combine(100*((A if A is not None else 0) / B)).mean().timeshift('12w').publish(label='12w', enable=False)
+        
+        F = (((C-D)/C)*100).publish(label='% 4 week Change')
+        G = (((C-E)/C)*100).publish(label='% 12 week Change')
+    EOF
+    secondary_visualization = "Radial"
+    sort_by                 = "-sf_metric"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "lime_green"
+        gt    = 2
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 10
+    }
+    color_scale {
+        color = "red"
+        gt    = 340282346638528860000000000000000000000
+        gte   = 0
+        lt    = 340282346638528860000000000000000000000
+        lte   = 2
+    }
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_service"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_environment"
+    }
+
+    viz_options {
+        display_name = "% 12 week Change"
+        label        = "% 12 week Change"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "% 4 week Change"
+        label        = "% 4 week Change"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "12w"
+        label        = "12w"
+    }
+    viz_options {
+        display_name = "4w"
+        label        = "4w"
+    }
+    viz_options {
+        display_name = "Errors"
+        label        = "A"
+    }
+    viz_options {
+        display_name = "Requests"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "Today"
+        label        = "Today"
+        value_suffix = "%"
+    }
+}
+# signalfx_list_chart.APM_IMM-Exec_6:
+resource "signalfx_list_chart" "APM_IMM-Exec_6" {
+    color_by                = "Dimension"
+    description             = "Service Saturation of CPU/MEM/DISK Top and Bottom 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 1
+    name                    = "Host saturation 12 week comparison"
+    program_text            = <<-EOF
+        f = filter('sf_environment', '*') and filter('sf_service', '*')
+        A = data('cpu.utilization', filter=f).mean(by='sf_service').publish(label='A', enable=False)
+        B = data('memory.utilization', filter=f).mean(by='sf_service').publish(label='B', enable=False)
+        C = data('disk.summary_utilization', filter=f).mean(by='sf_service').publish(label='C', enable=False)
+        D = max(A, B, C).publish(label='Saturation', enable=False)
+        E = max(A, B, C).timeshift('12w').publish(label='Saturation-12w', enable=False)
+        
+        G = (((E-D)/D)*100).mean(over='7d').top(count=5).publish(label='% Change')
+        H = (((E-D)/D)*100).mean(over='7d').bottom(count=5).publish(label='% Change')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "+value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "cloud.account.id"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "cloud.availability_zone"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "cloud.platform"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "cloud.provider"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "gcp_id"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "host"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "host.id"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "host.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "host.type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "k8s.cluster.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "k8s.node.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "kubernetes_cluster"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "kubernetes_node"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "kubernetes_node_uid"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "metric_source"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "os.type"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_service"
+    }
+
+    viz_options {
+        display_name = "% Change"
+        label        = "% Change"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Saturation"
+        label        = "Saturation"
+    }
+    viz_options {
+        display_name = "Saturation-12w"
+        label        = "Saturation-12w"
+    }
+    viz_options {
+        display_name = "cpu.utilization"
+        label        = "A"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "disk.summary_utilization"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "memory.utilization"
+        label        = "B"
+        value_suffix = "%"
+    }
+}
+# signalfx_list_chart.APM_IMM-Exec_7:
+resource "signalfx_list_chart" "APM_IMM-Exec_7" {
+    color_by                = "Scale"
+    description             = "Service Saturation of mean CPU/MEM/DISK compared"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 1
+    name                    = "Host saturation (4 & 12 week comparisons)"
+    program_text            = <<-EOF
+        f = filter('sf_environment', '*') and filter('sf_service', '*')
+        A = data('cpu.utilization', filter=f).mean(by='sf_service').publish(label='A', enable=False)
+        B = data('memory.utilization', filter=f).mean(by='sf_service').publish(label='B', enable=False)
+        C = data('disk.summary_utilization', filter=f).mean(by='sf_service').publish(label='C', enable=False)
+        D = max(A, B, C).mean().publish(label='Today')
+        E = max(A, B, C).mean().timeshift('4w').publish(label='% 4', enable=False)
+        G = max(A, B, C).mean().timeshift('12w').publish(label='% 12', enable=False)
+        H = (((D-E)/D)*100).publish(label='% 4 week Change')
+        I = (((D-G)/D)*100).publish(label='% 12 week Change')
+    EOF
+    secondary_visualization = "Radial"
+    sort_by                 = "-sf_metric"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    color_scale {
+        color = "lime_green"
+        gt    = 70
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 100
+    }
+    color_scale {
+        color = "red"
+        gt    = 340282346638528860000000000000000000000
+        gte   = 0
+        lt    = 340282346638528860000000000000000000000
+        lte   = 50
+    }
+    color_scale {
+        color = "vivid_yellow"
+        gt    = 50
+        gte   = 340282346638528860000000000000000000000
+        lt    = 340282346638528860000000000000000000000
+        lte   = 70
+    }
+
+    legend_options_fields {
+        enabled  = false
+        property = "cloud.account.id"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "cloud.availability_zone"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "cloud.platform"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "cloud.provider"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "gcp_id"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "host"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "host.id"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "host.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "host.type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "k8s.cluster.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "k8s.node.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "kubernetes_cluster"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "kubernetes_node"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "kubernetes_node_uid"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "metric_source"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "os.type"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_service"
+    }
+
+    viz_options {
+        display_name = "% 12 week Change"
+        label        = "% 12 week Change"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "% 12"
+        label        = "% 12"
+    }
+    viz_options {
+        display_name = "% 4 week Change"
+        label        = "% 4 week Change"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "% 4"
+        label        = "% 4"
+    }
+    viz_options {
+        display_name = "Today"
+        label        = "Today"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "cpu.utilization"
+        label        = "A"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "disk.summary_utilization"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "memory.utilization"
+        label        = "B"
+        value_suffix = "%"
+    }
+}

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Billing-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Billing-Exec.tf
@@ -1,0 +1,778 @@
+# signalfx_dashboard.Billing-Exec:
+resource "signalfx_dashboard" "Billing-Exec" {
+    depends_on = [signalfx_dashboard.RUM-Exec]
+    charts_resolution = "default"
+    dashboard_group   = signalfx_dashboard_group.exec_dashboard_group.id
+    description       = "Executive Level Dashboard for Billing Metrics"
+    name              = "Billing - Exec"
+    time_range        = "-12w"
+
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_10.id
+        column   = 6
+        height   = 2
+        row      = 4
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_8.id
+        column   = 0
+        height   = 2
+        row      = 4
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_9.id
+        column   = 3
+        height   = 2
+        row      = 4
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_2.id
+        column   = 6
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_0.id
+        column   = 0
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_4.id
+        column   = 0
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_5.id
+        column   = 3
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_6.id
+        column   = 6
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_7.id
+        column   = 9
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_3.id
+        column   = 9
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Billing-Exec_1.id
+        column   = 3
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+
+}
+
+# signalfx_list_chart.Billing-Exec_0:
+resource "signalfx_list_chart" "Billing-Exec_0" {
+    color_by                = "Dimension"
+    description             = "APM - Hosts Billing metric (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "APM - Hosts"
+    program_text            = <<-EOF
+        C = data('sf.org.apm.numContainers').mean(over='7d').publish(label='C')
+        H = data('sf.org.apm.numHosts').mean(over='7d').publish(label='H')
+        I = (C+H).publish(label='I')
+        J = (C+H).timeshift('4w').publish(label='J', enable=False)
+        K = (C+H).timeshift('12w').publish(label='K', enable=False)
+        G = (((I-K)/K)*100).publish(label='G')
+        F = (((I-J)/J)*100).publish(label='F')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+
+    viz_options {
+        display_name = "12 Week Combined Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "12w Combined Hosts"
+        label        = "K"
+    }
+    viz_options {
+        display_name = "4 Week Combined Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4w Combined Hosts"
+        label        = "J"
+    }
+    viz_options {
+        display_name = "Current Combined Hosts"
+        label        = "I"
+    }
+    viz_options {
+        display_name = "Current Containers"
+        label        = "C"
+    }
+    viz_options {
+        display_name = "Current Hosts"
+        label        = "H"
+    }
+}
+# signalfx_list_chart.Billing-Exec_1:
+resource "signalfx_list_chart" "Billing-Exec_1" {
+    color_by                = "Dimension"
+    description             = "APM - TPM Span Bytes Billing metric"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "APM - Span Bytes Received"
+    program_text            = <<-EOF
+        C = data('sf.org.apm.numSpanBytesReceived', rollup='sum').mean(over='7d').publish(label='C')
+        D = data('sf.org.apm.numSpanBytesReceived', rollup='sum').mean(over='7d').timeshift('4w').publish(label='D', enable=False)
+        E = data('sf.org.apm.numSpanBytesReceived', rollup='sum').mean(over='7d').timeshift('12w').publish(label='E', enable=False)
+        F = (((C-D)/D)*100).publish(label='F')
+        G = (((C-E)/E)*100).publish(label='G')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+
+    viz_options {
+        display_name = "12 Week Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4 Week Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Current Span Bytes"
+        label        = "C"
+        value_unit   = "Byte"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+    }
+    viz_options {
+        display_name = "E"
+        label        = "E"
+    }
+}
+# signalfx_list_chart.Billing-Exec_2:
+resource "signalfx_list_chart" "Billing-Exec_2" {
+    color_by                = "Dimension"
+    description             = "APM - TPM Troubleshooting Metric Sets Billing metric (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "APM - Troubleshooting Metric Sets"
+    program_text            = <<-EOF
+        C = data('sf.org.apm.numTroubleshootingMetricSets').mean(over='7d').publish(label='C')
+        D = data('sf.org.apm.numTroubleshootingMetricSets').mean(over='7d').timeshift('4w').publish(label='D', enable=False)
+        E = data('sf.org.apm.numTroubleshootingMetricSets').mean(over='7d').timeshift('12w').publish(label='E', enable=False)
+        F = (((C-D)/D)*100).publish(label='F')
+        G = (((C-E)/E)*100).publish(label='G')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+
+    viz_options {
+        display_name = "12 Week Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4 Week Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Current Troubleshooting Metric Sets"
+        label        = "C"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+    }
+    viz_options {
+        display_name = "E"
+        label        = "E"
+    }
+}
+# signalfx_list_chart.Billing-Exec_3:
+resource "signalfx_list_chart" "Billing-Exec_3" {
+    color_by                = "Dimension"
+    description             = "APM - TPM Traces Billing metric (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "APM - Traces Per Minute"
+    program_text            = <<-EOF
+        C = data('sf.org.apm.numTracesReceived').mean(over='7d').publish(label='C')
+        D = data('sf.org.apm.numTracesReceived').mean(over='7d').timeshift('4w').publish(label='D', enable=False)
+        E = data('sf.org.apm.numTracesReceived').mean(over='7d').timeshift('12w').publish(label='E', enable=False)
+        F = (((C-D)/D)*100).publish(label='F')
+        G = (((C-E)/E)*100).publish(label='G')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+
+    viz_options {
+        display_name = "12 Week Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4 Week Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Current TPM"
+        label        = "C"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+    }
+    viz_options {
+        display_name = "E"
+        label        = "E"
+    }
+}
+# signalfx_list_chart.Billing-Exec_4:
+resource "signalfx_list_chart" "Billing-Exec_4" {
+    color_by                = "Dimension"
+    description             = "IMM - Hosts Billing metric (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "IMM - Hosts"
+    program_text            = <<-EOF
+        C = data('sf.org.numResourcesMonitored', filter=filter('resourceType', 'container')).mean(over='7d').publish(label='C')
+        H = data('sf.org.numResourcesMonitored', filter=filter('resourceType', 'host')).mean(over='7d').publish(label='H')
+        I = (C+H).publish(label='I')
+        J = (C+H).timeshift('4w').publish(label='J', enable=False)
+        K = (C+H).timeshift('12w').publish(label='K', enable=False)
+        G = (((I-K)/K)*100).publish(label='G')
+        F = (((I-J)/J)*100).publish(label='F')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "resourceType"
+    }
+
+    viz_options {
+        display_name = "12 Week Combined Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "12w Combined Hosts"
+        label        = "K"
+    }
+    viz_options {
+        display_name = "4 Week Combined Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4w Combined Hosts"
+        label        = "J"
+    }
+    viz_options {
+        display_name = "Current Combined Hosts"
+        label        = "I"
+    }
+    viz_options {
+        display_name = "Current Containers"
+        label        = "C"
+    }
+    viz_options {
+        display_name = "Current Hosts"
+        label        = "H"
+    }
+}
+# signalfx_list_chart.Billing-Exec_5:
+resource "signalfx_list_chart" "Billing-Exec_5" {
+    color_by                = "Dimension"
+    description             = "IMM - Custom Metrics Billing metric (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "IMM - Custom Metrics"
+    program_text            = <<-EOF
+        C = data('sf.org.numCustomMetrics').mean(over='7d').publish(label='C')
+        D = data('sf.org.numCustomMetrics').mean(over='7d').timeshift('4w').publish(label='D', enable=False)
+        E = data('sf.org.numCustomMetrics').mean(over='7d').timeshift('12w').publish(label='E', enable=False)
+        F = (((C-D)/D)*100).publish(label='F')
+        G = (((C-E)/E)*100).publish(label='G')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+
+    viz_options {
+        display_name = "12 Week Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4 Week Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Current Custom Metrics"
+        label        = "C"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+    }
+    viz_options {
+        display_name = "E"
+        label        = "E"
+    }
+}
+# signalfx_list_chart.Billing-Exec_6:
+resource "signalfx_list_chart" "Billing-Exec_6" {
+    color_by                = "Dimension"
+    description             = "IMM - High Resolution Metrics Billing metric (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "IMM - High Resolution Metrics"
+    program_text            = <<-EOF
+        C = data('sf.org.numHighResolutionMetrics').mean(over='7d').publish(label='C')
+        D = data('sf.org.numHighResolutionMetrics').mean(over='7d').timeshift('4w').publish(label='D', enable=False)
+        E = data('sf.org.numHighResolutionMetrics').mean(over='7d').timeshift('12w').publish(label='E', enable=False)
+        F = (((C-D)/D)*100).publish(label='F')
+        G = (((C-E)/E)*100).publish(label='G')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+
+    viz_options {
+        display_name = "12 Week Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4 Week Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Current High Resolution Metrics"
+        label        = "C"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+    }
+    viz_options {
+        display_name = "E"
+        label        = "E"
+    }
+}
+# signalfx_list_chart.Billing-Exec_7:
+resource "signalfx_list_chart" "Billing-Exec_7" {
+    color_by                = "Dimension"
+    description             = "IMM - Data Points Per Minute Billing metric (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "IMM - Data Points Per Minute"
+    program_text            = <<-EOF
+        C = data('sf.org.numDatapointsReceivedByToken').sum().mean(over='7d').publish(label='C')
+        D = data('sf.org.numDatapointsReceivedByToken').sum().mean(over='7d').timeshift('4w').publish(label='D', enable=False)
+        E = data('sf.org.numDatapointsReceivedByToken').sum().mean(over='7d').timeshift('12w').publish(label='E', enable=False)
+        F = (((C-D)/D)*100).publish(label='F')
+        G = (((C-E)/E)*100).publish(label='G')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "tokenId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "category"
+    }
+
+    viz_options {
+        display_name = "12 Week Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4 Week Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Current DPM"
+        label        = "C"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+    }
+    viz_options {
+        display_name = "E"
+        label        = "E"
+    }
+}
+# signalfx_list_chart.Billing-Exec_8:
+resource "signalfx_list_chart" "Billing-Exec_8" {
+    color_by                = "Dimension"
+    description             = "Logs - Ingest Bytes Billing metric (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Logs - Ingest Bytes"
+    program_text            = <<-EOF
+        C = data('sf.org.log.numContentBytesReceivedByToken').sum().mean(over='7d').publish(label='C')
+        D = data('sf.org.log.numContentBytesReceivedByToken').sum().mean(over='7d').timeshift('4w').publish(label='D', enable=False)
+        E = data('sf.org.log.numContentBytesReceivedByToken').sum().mean(over='7d').timeshift('12w').publish(label='E', enable=False)
+        F = (((C-D)/D)*100).publish(label='F')
+        G = (((C-E)/E)*100).publish(label='G')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "tokenId"
+    }
+
+    viz_options {
+        display_name = "12 Week Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4 Week Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Current Log Ingest"
+        label        = "C"
+        value_unit   = "Byte"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+        value_unit   = "Byte"
+    }
+    viz_options {
+        display_name = "E"
+        label        = "E"
+        value_unit   = "Byte"
+    }
+}
+# signalfx_list_chart.Billing-Exec_9:
+resource "signalfx_list_chart" "Billing-Exec_9" {
+    color_by                = "Dimension"
+    description             = "Logs - Per Host Ingest Bytes Billing metric (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Logs - Per Host Ingest Bytes"
+    program_text            = <<-EOF
+        H = data('sf.org.numResourcesMonitored').sum().publish(label='H', enable=False)
+        C = data('sf.org.log.numContentBytesReceivedByToken').sum().mean(over='7d').publish(label='C', enable=False)
+        I = (C / H).publish(label='I')
+        J = (C / H).timeshift('4w').publish(label='J', enable=False)
+        K = (C / H).timeshift('12w').publish(label='K', enable=False)
+        F = (((I-J)/J)*100).publish(label='F')
+        G = (((I-K)/K)*100).publish(label='G')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "tokenId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "resourceType"
+    }
+
+    viz_options {
+        display_name = "12 Week Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "12w Log Ingest per Host"
+        label        = "K"
+        value_unit   = "Byte"
+    }
+    viz_options {
+        display_name = "4 Week Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4w Log Ingest per Host"
+        label        = "J"
+        value_unit   = "Byte"
+    }
+    viz_options {
+        display_name = "Current Log Ingest"
+        label        = "C"
+        value_unit   = "Byte"
+    }
+    viz_options {
+        display_name = "Log Ingest per Host"
+        label        = "I"
+        value_unit   = "Byte"
+    }
+    viz_options {
+        display_name = "Total Hosts"
+        label        = "H"
+    }
+}
+# signalfx_list_chart.Billing-Exec_10:
+resource "signalfx_list_chart" "Billing-Exec_10" {
+    color_by                = "Dimension"
+    description             = "RUM/APM - RUM Span Bytes (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "RUM/APM - RUM Span Bytes"
+    program_text            = <<-EOF
+        C = data('sf.org.rum.numSpanBytesReceivedByToken').sum().mean(over='7d').publish(label='C')
+        D = data('sf.org.rum.numSpanBytesReceivedByToken').sum().mean(over='7d').timeshift('4w').publish(label='D', enable=False)
+        E = data('sf.org.rum.numSpanBytesReceivedByToken').sum().mean(over='7d').timeshift('12w').publish(label='E', enable=False)
+        F = (((C-D)/D)*100).publish(label='F')
+        G = (((C-E)/E)*100).publish(label='G')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "tokenId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "category"
+    }
+
+    viz_options {
+        display_name = "12 Week Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4 Week Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Current Rum Span Bytes"
+        label        = "C"
+        value_unit   = "Byte"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+        value_unit   = "Byte"
+    }
+    viz_options {
+        display_name = "E"
+        label        = "E"
+        value_unit   = "Byte"
+    }
+}

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Logs-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Logs-Exec.tf
@@ -1,0 +1,564 @@
+
+# signalfx_dashboard.Logs-Exec:
+resource "signalfx_dashboard" "Logs-Exec" {
+    depends_on = [signalfx_dashboard.APM_IMM-Exec]
+    charts_resolution = "default"
+    dashboard_group   = signalfx_dashboard_group.exec_dashboard_group.id
+    description       = "Log Observer Executive Dashboard"
+    name              = "Logs - Exec"
+    time_range        = "-31d"
+
+    chart {
+        chart_id = signalfx_list_chart.Logs-Exec_6.id
+        column   = 9
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Logs-Exec_5.id
+        column   = 6
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Logs-Exec_0.id
+        column   = 0
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Logs-Exec_1.id
+        column   = 3
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Logs-Exec_3.id
+        column   = 9
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.Logs-Exec_2.id
+        column   = 6
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_time_chart.Logs-Exec_7.id
+        column   = 0
+        height   = 1
+        row      = 3
+        width    = 6
+    }
+    chart {
+        chart_id = signalfx_text_chart.Logs-Exec_4.id
+        column   = 0
+        height   = 1
+        row      = 2
+        width    = 6
+    }
+
+}
+
+# signalfx_list_chart.Logs-Exec_0:
+resource "signalfx_list_chart" "Logs-Exec_0" {
+    color_by                = "Dimension"
+    description             = "Logs Received per Day by Token Top 5 (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Logs Received per Day by Token"
+    program_text            = "C = data('sf.org.numLogsReceivedByToken', rollup='sum').sum(by=['tokenName']).mean(over='7d').sum(over='1d').top(count=5).publish(label='C')"
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "tokenId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "severity"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ruleId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_derived_from"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "deployment.environment"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "tokenName"
+    }
+
+    viz_options {
+        display_name = "Events Received"
+        label        = "C"
+    }
+}
+# signalfx_list_chart.Logs-Exec_1:
+resource "signalfx_list_chart" "Logs-Exec_1" {
+    color_by                = "Dimension"
+    description             = "Logs Received per Day by Token Top & Bottom 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Logs Received per Day by Token 12 week comparison"
+    program_text            = <<-EOF
+        A = data('sf.org.numLogsReceivedByToken').sum(by=['tokenName']).mean(over='7d').sum(over='1d').publish(label='A', enable=False)
+        B = data('sf.org.numLogsReceivedByToken').sum(by=['tokenName']).timeshift('12w').mean(over='7d').sum(over='1d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['tokenName']).mean(over='7d').fill(0).top(5).publish(label='C')
+        D = (((A-B)/B)*100).mean(by=['tokenName']).mean(over='7d').fill(0).bottom(5).publish(label='D')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "check"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "world_region"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "country"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "location"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "position"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "status"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "severity"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "tokenName"
+    }
+
+    viz_options {
+        display_name = "D"
+        label        = "D"
+    }
+    viz_options {
+        display_name = "Log Events by Token"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.webvitals_fid.time.ns.p75 - Sum by sf_ua_browsername"
+        label        = "A"
+    }
+    viz_options {
+        display_name = "rum.webvitals_fid.time.ns.p75 - Sum by sf_ua_browsername"
+        label        = "B"
+        value_unit   = "Millisecond"
+    }
+}
+# signalfx_list_chart.Logs-Exec_2:
+resource "signalfx_list_chart" "Logs-Exec_2" {
+    color_by                = "Dimension"
+    description             = "Profiling Logs Received per Day by Token Top 5 (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Profiling Logs Received per Day by Token"
+    program_text            = "C = data('sf.org.profiling.numLogsReceivedByToken', rollup='sum').sum(by=['tokenName']).mean(over='7d').sum(over='1d').top(count=5).publish(label='C')"
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "tokenId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "severity"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ruleId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_derived_from"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "deployment.environment"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "tokenName"
+    }
+
+    viz_options {
+        display_name = "Events Received"
+        label        = "C"
+    }
+}
+# signalfx_list_chart.Logs-Exec_3:
+resource "signalfx_list_chart" "Logs-Exec_3" {
+    color_by                = "Dimension"
+    description             = "Logs Profiling Logs Received per Day by Token Top & Bottom 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Profiling Logs Received per Day by Token 12 week comparison"
+    program_text            = <<-EOF
+        A = data('sf.org.profiling.numLogsReceivedByToken').sum(by=['tokenName']).mean(over='7d').sum(over='1d').publish(label='A', enable=False)
+        B = data('sf.org.profiling.numLogsReceivedByToken').sum(by=['tokenName']).timeshift('12w').mean(over='7d').sum(over='1d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['tokenName']).mean(over='7d').fill(0).top(5).publish(label='C')
+        D = (((A-B)/B)*100).mean(by=['tokenName']).mean(over='7d').fill(0).bottom(5).publish(label='D')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "check"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "world_region"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "country"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "location"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "position"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "status"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "severity"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "tokenName"
+    }
+
+    viz_options {
+        display_name = "Log Events by Token Bottom"
+        label        = "D"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Log Events by Token Top"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.webvitals_fid.time.ns.p75 - Sum by sf_ua_browsername"
+        label        = "A"
+    }
+    viz_options {
+        display_name = "rum.webvitals_fid.time.ns.p75 - Sum by sf_ua_browsername"
+        label        = "B"
+        value_unit   = "Millisecond"
+    }
+}
+# signalfx_text_chart.Logs-Exec_4:
+resource "signalfx_text_chart" "Logs-Exec_4" {
+    markdown = <<-EOF
+        ###_Log Observer Events charts require this query_
+        ##### Note: Logs ingested with Log Observer Connect will need to be metricized in Splunk Cloud
+        
+        **Setup Log Pipeline Management Metric:**
+        ##### -Matching Condition: Match All
+        ##### -Operation: count
+        ##### -Dimensions: ["severity","deployment.environment"]
+        ###### (Replace "deployment.environment" with your environment dimension)
+        ##### -Field: null
+        ##### -Metric Name: logs.events.count
+        ##### -Metric Type: COUNTER
+    EOF
+    name     = "LO Events Query"
+}
+# signalfx_list_chart.Logs-Exec_5:
+resource "signalfx_list_chart" "Logs-Exec_5" {
+    color_by                = "Dimension"
+    description             = "Events per Day by Log Level (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Events per Day by Log Level"
+    program_text            = <<-EOF
+        C = data('logs.events.count', rollup='sum').sum(by=['severity'], allow_missing=['severity']).mean(over='7d').sum(over='1d').publish(label='C')
+        
+        ### Relies on a Log Pipeline Management Metric
+        ### Setup with below information
+        ## Matching Condition: Match All
+        ## Operation: count
+        ## Dimensions: ["severity","deployment.environment"]
+        ## Field: null
+        ## Metric Name: logs.events.count
+        ## Metric Type: COUNTER
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "severity"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ruleId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_derived_from"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "deployment.environment"
+    }
+
+    }
+# signalfx_list_chart.Logs-Exec_6:
+resource "signalfx_list_chart" "Logs-Exec_6" {
+    color_by                = "Dimension"
+    description             = "Logs Events per Day by Log Level (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Events per Day by Log Level 12 week comparison"
+    program_text            = <<-EOF
+        A = data('logs.events.count').sum(by=['severity'], allow_missing=['severity']).mean(over='7d').sum(over='1d').publish(label='A', enable=False)
+        B = data('logs.events.count').sum(by=['severity'], allow_missing=['severity']).timeshift('12w').mean(over='7d').sum(over='1d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['severity'], allow_missing=['severity']).mean(over='7d').publish(label='C')
+        
+        ### Relies on a Log Pipeline Management Metric
+        ### Setup with below information
+        ## Matching Condition: Match All
+        ## Operation: count
+        ## Dimensions: ["severity","deployment.environment"]
+        ## Field: null
+        ## Metric Name: logs.events.count
+        ## Metric Type: COUNTER
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = true
+        property = "check"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "world_region"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "country"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "location"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "position"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "status"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "severity"
+    }
+
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.webvitals_fid.time.ns.p75 - Sum by sf_ua_browsername"
+        label        = "A"
+    }
+    viz_options {
+        display_name = "rum.webvitals_fid.time.ns.p75 - Sum by sf_ua_browsername"
+        label        = "B"
+    }
+}
+# signalfx_time_chart.Logs-Exec_7:
+resource "signalfx_time_chart" "Logs-Exec_7" {
+    axes_include_zero  = false
+    axes_precision     = 0
+    color_by           = "Dimension"
+    description        = "Events Received per Day by Log Level (7 day avg)"
+    disable_sampling   = false
+    max_delay          = 0
+    minimum_resolution = 0
+    name               = "Events Received per Day by Log Level"
+    plot_type          = "AreaChart"
+    program_text       = <<-EOF
+        C = data('logs.events.count', rollup='sum').sum(by=['severity'], allow_missing=['severity']).sum(over='1d').mean(over='7d').publish(label='Event Count')
+        
+        ### Relies on a Log Pipeline Management Metric
+        ### Setup with below information
+        ## Matching Condition: Match All
+        ## Operation: count
+        ## Dimensions: ["severity","deployment.environment"]
+        ## Field: null
+        ## Metric Name: logs.events.count
+        ## Metric Type: COUNTER
+    EOF
+    show_data_markers  = false
+    show_event_lines   = false
+    stacked            = true
+    time_range         = 900
+    unit_prefix        = "Metric"
+
+    histogram_options {
+        color_theme = "red"
+    }
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "severity"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ruleId"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_derived_from"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "deployment.environment"
+    }
+
+    viz_options {
+        axis         = "left"
+        display_name = "Event Count"
+        label        = "Event Count"
+    }
+}

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/RUM-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/RUM-Exec.tf
@@ -1,0 +1,946 @@
+# signalfx_dashboard.RUM-Exec:
+resource "signalfx_dashboard" "RUM-Exec" {
+    depends_on = [signalfx_dashboard.Logs-Exec]
+    charts_resolution = "default"
+    dashboard_group   = signalfx_dashboard_group.exec_dashboard_group.id
+    name              = "RUM - Exec"
+    time_range        = "-140d"
+
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_7.id
+        column   = 9
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_3.id
+        column   = 9
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_8.id
+        column   = 0
+        height   = 2
+        row      = 4
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_10.id
+        column   = 6
+        height   = 2
+        row      = 4
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_2.id
+        column   = 6
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_4.id
+        column   = 0
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_5.id
+        column   = 3
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_9.id
+        column   = 3
+        height   = 2
+        row      = 4
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_6.id
+        column   = 6
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_0.id
+        column   = 0
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.RUM-Exec_1.id
+        column   = 3
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+
+}
+
+# signalfx_list_chart.RUM-Exec_0:
+resource "signalfx_list_chart" "RUM-Exec_0" {
+    color_by                = "Dimension"
+    description             = "Browser Request count change (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "RUM Browser Request 12 week comparison"
+    program_text            = <<-EOF
+        A = data('rum.page_view.count', filter=filter('sf_ua_browsername', '*')).mean(by=['sf_ua_browsername']).mean(over='7d').publish(label='A', enable=False)
+        B = data('rum.page_view.count', filter=filter('sf_ua_browsername', '*')).mean(by=['sf_ua_browsername']).mean(over='7d').timeshift('12w').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['sf_ua_browsername']).mean(over='7d').publish(label='C')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_ua_browsername"
+    }
+
+    viz_options {
+        display_name = "B"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.page_view.count - Mean by sf_ua_browsername - Mean(7d)"
+        label        = "A"
+        value_unit   = "Millisecond"
+    }
+}
+# signalfx_list_chart.RUM-Exec_1:
+resource "signalfx_list_chart" "RUM-Exec_1" {
+    color_by                = "Dimension"
+    description             = "Browser Errors count change (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "RUM Errors Request 12 week comparison"
+    program_text            = <<-EOF
+        A = data('rum.client_error.count', filter=filter('sf_ua_browsername', '*')).mean(by=['sf_ua_browsername']).mean(over='7d').publish(label='A', enable=False)
+        B = data('rum.client_error.count', filter=filter('sf_ua_browsername', '*')).mean(by=['sf_ua_browsername']).mean(over='7d').timeshift('12w').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['sf_ua_browsername']).mean(over='7d').publish(label='C')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_ua_browsername"
+    }
+
+    viz_options {
+        display_name = "B"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.client_error.count - Mean by sf_ua_browsername - Mean(7d)"
+        label        = "A"
+        value_unit   = "Millisecond"
+    }
+}
+# signalfx_list_chart.RUM-Exec_2:
+resource "signalfx_list_chart" "RUM-Exec_2" {
+    color_by                = "Dimension"
+    description             = "Browser Latency change (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "RUM Browser Latency 12 week comparison"
+    program_text            = <<-EOF
+        A = data('rum.page_view.time.ns.p75', filter=filter('sf_ua_browsername', '*')).mean(by=['sf_ua_browsername']).mean(over='7d').scale(0.000001).publish(label='A', enable=False)
+        B = data('rum.page_view.time.ns.p75', filter=filter('sf_ua_browsername', '*')).mean(by=['sf_ua_browsername']).mean(over='7d').timeshift('12w').scale(0.000001).publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['sf_ua_browsername']).mean(over='7d').publish(label='C')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_ua_browsername"
+    }
+
+    viz_options {
+        display_name = "B"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.page_view.time.ns.p75 - Mean by sf_ua_browsername - Mean(7d) - Scale:0.000001"
+        label        = "A"
+        value_unit   = "Millisecond"
+    }
+}
+# signalfx_list_chart.RUM-Exec_3:
+resource "signalfx_list_chart" "RUM-Exec_3" {
+    color_by                = "Metric"
+    description             = "Web Vitals Monthly Averages"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Web Vitals"
+    program_text            = <<-EOF
+        A = data('rum.webvitals_fid.time.ns.p75').scale(0.000001).mean(cycle='month', cycle_start='1d', partial_values=True).mean().publish(label='A')
+        B = data('rum.webvitals_lcp.time.ns.p75').scale(0.000001).mean(cycle='month', cycle_start='1d', partial_values=True).mean().publish(label='B')
+        C = data('rum.webvitals_cls.score.p75').mean(cycle='month', cycle_start='1d', partial_values=True).mean().publish(label='C')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-sf_metric"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+
+    viz_options {
+        display_name = "Cumulative Layout Shift (1mo)"
+        label        = "C"
+        value_suffix = "pixels"
+    }
+    viz_options {
+        display_name = "First Input Delay P75 (1mo)"
+        label        = "A"
+        value_unit   = "Millisecond"
+    }
+    viz_options {
+        display_name = "Largest Contentful Paint P75 (1mo)"
+        label        = "B"
+        value_unit   = "Millisecond"
+    }
+}
+# signalfx_list_chart.RUM-Exec_4:
+resource "signalfx_list_chart" "RUM-Exec_4" {
+    color_by                = "Dimension"
+    description             = "Request rate by App and Version Top 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "RUM App Request rate 12 week comparison"
+    program_text            = <<-EOF
+        A = data('rum.workflow.count', rollup='rate').sum(by=['app', 'app.version'], allow_missing=['app', 'app.version']).mean(over='7d').publish(label='A', enable=False)
+        B = data('rum.workflow.count', rollup='rate').sum(by=['app', 'app.version'], allow_missing=['app', 'app.version']).timeshift('12w').mean(over='7d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['app', 'app.version'], allow_missing=['app', 'app.version']).mean(over='7d').top(count=5).publish(label='C')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 3600
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = true
+        property = "app"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "app.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "net.host.connection.type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_environment"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_error"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_node_type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_operation"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_product"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ua_browsername"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ua_osname"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "workflow.name"
+    }
+
+    viz_options {
+        display_name = "B"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.workflow.count - Sum by workflow.name"
+        label        = "A"
+    }
+}
+# signalfx_list_chart.RUM-Exec_5:
+resource "signalfx_list_chart" "RUM-Exec_5" {
+    color_by                = "Dimension"
+    description             = "Request Errors by App and Version Top 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "RUM App Errors 12 week comparison"
+    program_text            = <<-EOF
+        A = data('rum.app_error.count', rollup='rate').sum(by=['app', 'app.version'], allow_missing=['app', 'app.version']).mean(over='7d').publish(label='A', enable=False)
+        B = data('rum.app_error.count', rollup='rate').sum(by=['app', 'app.version'], allow_missing=['app', 'app.version']).timeshift('12w').mean(over='7d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['app', 'app.version'], allow_missing=['app', 'app.version']).mean(over='7d').top(count=5).publish(label='C')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 3600
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = true
+        property = "app"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "app.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "net.host.connection.type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_environment"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_error"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_node_type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_operation"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_product"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ua_browsername"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ua_osname"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "workflow.name"
+    }
+
+    viz_options {
+        display_name = "B"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.workflow.count - Sum by workflow.name"
+        label        = "A"
+    }
+}
+# signalfx_list_chart.RUM-Exec_6:
+resource "signalfx_list_chart" "RUM-Exec_6" {
+    color_by                = "Dimension"
+    description             = "Latency change by App and Version Top 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "RUM App Latency 12 week comparison"
+    program_text            = <<-EOF
+        A = data('rum.workflow.time.ns.p75', filter=filter('sf_environment', '*')).mean(by=['app']).mean(over='7d').publish(label='A', enable=False)
+        B = data('rum.workflow.time.ns.p75', filter=filter('sf_environment', '*')).mean().timeshift('12w').mean(over='7d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['app', 'app.version']).mean(over='7d').top(count=5).publish(label='C')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "+value"
+    time_range              = 3600
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = true
+        property = "app"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "app.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "net.host.connection.type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_environment"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_error"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_node_type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_operation"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_product"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ua_browsername"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ua_osname"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "workflow.name"
+    }
+
+    viz_options {
+        display_name = "B"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.workflow.count - Sum by workflow.name"
+        label        = "A"
+    }
+}
+# signalfx_list_chart.RUM-Exec_7:
+resource "signalfx_list_chart" "RUM-Exec_7" {
+    color_by                = "Dimension"
+    description             = "Crash Count by App and Version Top 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "App Crash Count 12 week comparison"
+    program_text            = <<-EOF
+        A = data('rum.crash.count', rollup='rate').sum(by=['app', 'app.version'], allow_missing=['app', 'app.version']).mean(over='7d').publish(label='A', enable=False)
+        B = data('rum.crash.count', rollup='rate').sum(by=['app', 'app.version'], allow_missing=['app', 'app.version']).timeshift('12w').mean(over='7d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['app', 'app.version'], allow_missing=['app', 'app.version']).mean(over='7d').top(count=5).publish(label='C')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 3600
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = true
+        property = "app"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "app.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "net.host.connection.type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_environment"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_error"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_node_type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_operation"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_product"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ua_browsername"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_ua_osname"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "workflow.name"
+    }
+
+    viz_options {
+        display_name = "B"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.workflow.count - Sum by workflow.name"
+        label        = "A"
+    }
+}
+# signalfx_list_chart.RUM-Exec_8:
+resource "signalfx_list_chart" "RUM-Exec_8" {
+    color_by                = "Dimension"
+    description             = "Workflow rate Top and Bottom 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "RUM Workflow rate 12 week comparison"
+    program_text            = <<-EOF
+        A = data('rum.workflow.count', filter=filter('sf_environment', '*') and filter('workflow.name', '*'), rollup='rate').sum(by=['workflow.name']).mean(over='7d').publish(label='A', enable=False)
+        B = data('rum.workflow.count', filter=filter('sf_environment', '*') and filter('workflow.name', '*'), rollup='rate').sum(by=['workflow.name']).timeshift('12w').mean(over='7d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['workflow.name']).mean(over='7d').top(count=5).publish(label='C')
+        D = (((A-B)/B)*100).mean(by=['workflow.name']).mean(over='7d').bottom(count=5).publish(label='D')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 3600
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "app"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "app.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "net.host.connection.type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_environment"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_error"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_node_type"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_operation"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_product"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_ua_browsername"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_ua_osname"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "workflow.name"
+    }
+
+    viz_options {
+        display_name = "B"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.workflow.count - Sum by workflow.name"
+        label        = "A"
+    }
+}
+# signalfx_list_chart.RUM-Exec_9:
+resource "signalfx_list_chart" "RUM-Exec_9" {
+    color_by                = "Dimension"
+    description             = "Workflow Errors Top and Bottom 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "RUM Workflow Errors 12 week comparison"
+    program_text            = <<-EOF
+        A = data('rum.workflow.count', filter=filter('sf_environment', '*') and filter('workflow.name', '*') and filter('sf_error', 'true'), rollup='rate').sum(by=['workflow.name']).mean(over='7d').publish(label='A', enable=False)
+        
+        
+        B = data('rum.workflow.count', filter=filter('sf_environment', '*') and filter('workflow.name', '*') and filter('sf_error', 'true'), rollup='rate').sum(by=['workflow.name']).timeshift('12w').mean(over='7d').publish(label='B', enable=False)
+        
+        
+        C = (((B-A)/A)*100).mean(by=['workflow.name']).mean(over='7d').top(count=5).publish(label='C')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "-value"
+    time_range              = 3600
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "app"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "app.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "net.host.connection.type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_environment"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_error"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_node_type"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_operation"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_product"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_ua_browsername"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_ua_osname"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "workflow.name"
+    }
+
+    viz_options {
+        display_name = "B"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.workflow.count - Sum by workflow.name"
+        label        = "A"
+    }
+}
+# signalfx_list_chart.RUM-Exec_10:
+resource "signalfx_list_chart" "RUM-Exec_10" {
+    color_by                = "Dimension"
+    description             = "Workflow latency change Top and Bottom 5 (12 week comparison)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "RUM Workflow Latency 12 week comparison"
+    program_text            = <<-EOF
+        A = data('rum.workflow.time.ns.p75', filter=filter('sf_environment', '*') and filter('workflow.name', '*')).mean(by=['workflow.name']).mean(over='7d').publish(label='A', enable=False)
+        B = data('rum.workflow.time.ns.p75', filter=filter('sf_environment', '*') and filter('workflow.name', '*')).mean(by=['workflow.name']).timeshift('12w').mean(over='7d').publish(label='B', enable=False)
+        C = (((A-B)/B)*100).mean(by=['workflow.name']).mean(over='7d').top(count=5).publish(label='C')
+        D = (((A-B)/B)*100).mean(by=['workflow.name']).mean(over='7d').bottom(count=5).publish(label='D')
+    EOF
+    secondary_visualization = "None"
+    sort_by                 = "+value"
+    time_range              = 3600
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "app"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "app.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "net.host.connection.type"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.name"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "os.version"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_environment"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_error"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_node_type"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_operation"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_product"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_ua_browsername"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_ua_osname"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "workflow.name"
+    }
+
+    viz_options {
+        display_name = "B"
+        label        = "B"
+    }
+    viz_options {
+        display_name = "C"
+        label        = "C"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "rum.workflow.count - Sum by workflow.name"
+        label        = "A"
+    }
+}

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/main.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/main.tf
@@ -1,0 +1,11 @@
+### Create a Dashboard Group for our Dashboards
+resource "signalfx_dashboard_group" "exec_dashboard_group" {
+  name        = "${var.o11y_prefix} Exec Level Dashboards"
+  description = "Executive Level Dashboards"
+
+  ### Note that if you use these features, you must use a user's
+  ### admin key to authenticate the provider, lest Terraform not be able
+  ### to modify the dashboard group in the future!
+  #authorized_writer_teams = [signalfx_team.mycoolteam.id]
+  #authorized_writer_users = ["abc123"]
+}

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/variables.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/variables.tf
@@ -1,0 +1,4 @@
+variable "o11y_prefix" {
+  type        = string
+  description = "Detector Prefix"
+}

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/versions.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source = "splunk-terraform/signalfx"
+      version = ">=6.13.1"
+    }
+  }
+}


### PR DESCRIPTION
This adds the executive dashboards from the dashboards folder to the terraform jumpstart (formerly known as https://github.com/signalfx/signalfx-jumpstart but now migrated to this repo by @rcastley!)

The Executive Dashboards use Org Level Metrics all orgs have to show 4w and 12 oriented changes in usage for APM/IMM/RUM/LO/Billing. Blog post here:
https://www.splunk.com/en_us/blog/tips-and-tricks/executive-lookout-observing-observability.html