### PR TITLE
Update Token-Usage-Exec.tf

### DIFF
--- a/dashboards-and-dashboard-groups/executive-dashboards/Token-Usage-Exec.tf
+++ b/dashboards-and-dashboard-groups/executive-dashboards/Token-Usage-Exec.tf
@@ -84,10 +84,6 @@ resource "signalfx_dashboard" "TOKEN-USAGE-EXEC" {
         width    = 3
     }
 
-    permissions {
-        parent = "E0jpPPqAYAA"
-    }
-
     variable {
         alias                  = "Environment"
         apply_if_exist         = false


### PR DESCRIPTION
reflects change from this commit https://github.com/splunk/observability-content-contrib/commit/e819ec80d86b26d2f79eef22c1122f3ff6bf24dd

Removes hardcoded org permissions id