### PR TITLE
updated export.py to include missing visualization

### DIFF
--- a/integration-examples/terraform-jumpstart/export_script/export.py
+++ b/integration-examples/terraform-jumpstart/export_script/export.py
@@ -152,6 +152,8 @@ def handle_dashboard(sfx, id, name, args):
             tf_type = "signalfx_heatmap_chart"
         elif chart_type == "Event":
             tf_type = "signalfx_event_feed_chart"
+        elif chart_type == "TableChart":
+            tf_type = "signalfx_table_chart"
         else:
             print(f"Exiting: Unknown chart type {chart_type}", file=sys.stderr)
             sys.exit()


### PR DESCRIPTION
Chart type "TableChart" was missing thus causing issues when exporting any dashboard containing a chart with the Table visualization.