### PR TITLE
Update coloring/logs in exec dashboards and terraform jumpstart exec dashboards

### DIFF
--- a/dashboards-and-dashboard-groups/executive-dashboards/APM_IMM-Exec.tf
+++ b/dashboards-and-dashboard-groups/executive-dashboards/APM_IMM-Exec.tf
@@ -128,13 +128,13 @@ resource "signalfx_list_chart" "APM_IMM-Exec_0" {
         color        = "lilac"
         display_name = "Requests"
         label        = "A"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"
         display_name = "Requests(-4w)"
         label        = "B"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
 }
 # signalfx_list_chart.APM_IMM-Exec_1:
@@ -186,19 +186,19 @@ resource "signalfx_list_chart" "APM_IMM-Exec_1" {
         color        = "lilac"
         display_name = "-12w"
         label        = "E"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"
         display_name = "-4w"
         label        = "D"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"
         display_name = "Today"
         label        = "C"
-        value_suffix = "requests/s"
+        value_suffix = " "
     }
 }
 # signalfx_list_chart.APM_IMM-Exec_2:
@@ -256,13 +256,13 @@ resource "signalfx_list_chart" "APM_IMM-Exec_2" {
         color        = "lilac"
         display_name = "Requests"
         label        = "A"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"
         display_name = "Requests(-4w)"
         label        = "B"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
 }
 # signalfx_list_chart.APM_IMM-Exec_3:
@@ -332,13 +332,13 @@ resource "signalfx_list_chart" "APM_IMM-Exec_3" {
         color        = "lilac"
         display_name = "-12w"
         label        = "E"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"
         display_name = "-4w"
         label        = "D"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"

--- a/dashboards-and-dashboard-groups/executive-dashboards/APM_IMM-Exec.tf
+++ b/dashboards-and-dashboard-groups/executive-dashboards/APM_IMM-Exec.tf
@@ -93,7 +93,7 @@ resource "signalfx_dashboard" "APM_IMM-Exec" {
 
 # signalfx_list_chart.APM_IMM-Exec_0:
 resource "signalfx_list_chart" "APM_IMM-Exec_0" {
-    color_by                = "Scale"
+    color_by                = "Metric"
     description             = "Traffic Change Top and Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -111,21 +111,6 @@ resource "signalfx_list_chart" "APM_IMM-Exec_0" {
     sort_by                 = "-value"
     time_range              = 900
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "lime_green"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
-    color_scale {
-        color = "red"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
 
     viz_options {
         color        = "brown"
@@ -218,7 +203,7 @@ resource "signalfx_list_chart" "APM_IMM-Exec_1" {
 }
 # signalfx_list_chart.APM_IMM-Exec_2:
 resource "signalfx_list_chart" "APM_IMM-Exec_2" {
-    color_by                = "Scale"
+    color_by                = "Metric"
     description             = "Latency (P90) Top and Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -254,21 +239,6 @@ resource "signalfx_list_chart" "APM_IMM-Exec_2" {
     sort_by                 = "+value"
     time_range              = 900
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "lime_green"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
-    color_scale {
-        color = "red"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
 
     viz_options {
         color        = "aquamarine"
@@ -379,7 +349,7 @@ resource "signalfx_list_chart" "APM_IMM-Exec_3" {
 }
 # signalfx_list_chart.APM_IMM-Exec_4:
 resource "signalfx_list_chart" "APM_IMM-Exec_4" {
-    color_by                = "Scale"
+    color_by                = "Metric"
     description             = "Error rate Top and Bottom 5 (12 week comparison)"
     disable_sampling        = true
     hide_missing_values     = false
@@ -400,21 +370,6 @@ resource "signalfx_list_chart" "APM_IMM-Exec_4" {
     sort_by                 = "+value"
     time_range              = 900
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "lime_green"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
-    color_scale {
-        color = "red"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
 
     legend_options_fields {
         enabled  = false
@@ -544,7 +499,7 @@ resource "signalfx_list_chart" "APM_IMM-Exec_5" {
 }
 # signalfx_list_chart.APM_IMM-Exec_6:
 resource "signalfx_list_chart" "APM_IMM-Exec_6" {
-    color_by                = "Dimension"
+    color_by                = "Metric"
     description             = "Service Saturation of CPU/MEM/DISK Top and Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false

--- a/dashboards-and-dashboard-groups/executive-dashboards/Logs-Exec.tf
+++ b/dashboards-and-dashboard-groups/executive-dashboards/Logs-Exec.tf
@@ -119,7 +119,7 @@ resource "signalfx_list_chart" "Logs-Exec_0" {
 }
 # signalfx_list_chart.Logs-Exec_1:
 resource "signalfx_list_chart" "Logs-Exec_1" {
-    color_by                = "Dimension"
+    color_by                = "Metric"
     description             = "Logs Received per Day by Token Top & Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -179,12 +179,13 @@ resource "signalfx_list_chart" "Logs-Exec_1" {
     }
 
     viz_options {
-        display_name = "D"
-        label        = "D"
+        display_name = "Log Events by Token (Top)"
+        label        = "C"
+        value_suffix = "%"
     }
     viz_options {
-        display_name = "Log Events by Token"
-        label        = "C"
+        display_name = "Log Events by Token (Bottom)"
+        label        = "D"
         value_suffix = "%"
     }
     viz_options {
@@ -256,7 +257,7 @@ resource "signalfx_list_chart" "Logs-Exec_2" {
 }
 # signalfx_list_chart.Logs-Exec_3:
 resource "signalfx_list_chart" "Logs-Exec_3" {
-    color_by                = "Dimension"
+    color_by                = "Metric"
     description             = "Logs Profiling Logs Received per Day by Token Top & Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -346,15 +347,7 @@ resource "signalfx_list_chart" "Logs-Exec_5" {
     name                    = "Events per Day by Log Level"
     program_text            = <<-EOF
         C = data('logs.events.count', rollup='sum').sum(by=['severity'], allow_missing=['severity']).mean(over='7d').sum(over='1d').publish(label='C')
-        
-        ### Relies on a Log Pipeline Management Metric
-        ### Setup with below information
-        ## Matching Condition: Match All
-        ## Operation: count
-        ## Dimensions: ["severity","deployment.environment"]
-        ## Field: null
-        ## Metric Name: logs.events.count
-        ## Metric Type: COUNTER
+        D = data('log_entry_count', rollup='sum').sum(by=['severity'], allow_missing=['severity']).mean(over='7d').sum(over='1d').publish(label='C')
     EOF
     secondary_visualization = "None"
     sort_by                 = "-value"
@@ -404,15 +397,10 @@ resource "signalfx_list_chart" "Logs-Exec_6" {
         A = data('logs.events.count').sum(by=['severity'], allow_missing=['severity']).mean(over='7d').sum(over='1d').publish(label='A', enable=False)
         B = data('logs.events.count').sum(by=['severity'], allow_missing=['severity']).timeshift('12w').mean(over='7d').sum(over='1d').publish(label='B', enable=False)
         C = (((A-B)/B)*100).mean(by=['severity'], allow_missing=['severity']).mean(over='7d').publish(label='C')
-        
-        ### Relies on a Log Pipeline Management Metric
-        ### Setup with below information
-        ## Matching Condition: Match All
-        ## Operation: count
-        ## Dimensions: ["severity","deployment.environment"]
-        ## Field: null
-        ## Metric Name: logs.events.count
-        ## Metric Type: COUNTER
+
+        D = data('log_entry_count').sum(by=['severity'], allow_missing=['severity']).mean(over='7d').sum(over='1d').publish(label='D', enable=False)
+        E = data('log_entry_count').sum(by=['severity'], allow_missing=['severity']).timeshift('12w').mean(over='7d').sum(over='1d').publish(label='E', enable=False)
+        F = (((D-E)/E)*100).mean(by=['severity'], allow_missing=['severity']).mean(over='7d').publish(label='F')
     EOF
     secondary_visualization = "None"
     sort_by                 = "-value"
@@ -462,6 +450,11 @@ resource "signalfx_list_chart" "Logs-Exec_6" {
         value_suffix = "%"
     }
     viz_options {
+        display_name = "F"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
         display_name = "rum.webvitals_fid.time.ns.p75 - Sum by sf_ua_browsername"
         label        = "A"
     }
@@ -483,15 +476,7 @@ resource "signalfx_time_chart" "Logs-Exec_7" {
     plot_type          = "AreaChart"
     program_text       = <<-EOF
         C = data('logs.events.count', rollup='sum').sum(by=['severity'], allow_missing=['severity']).sum(over='1d').mean(over='7d').publish(label='Event Count')
-        
-        ### Relies on a Log Pipeline Management Metric
-        ### Setup with below information
-        ## Matching Condition: Match All
-        ## Operation: count
-        ## Dimensions: ["severity","deployment.environment"]
-        ## Field: null
-        ## Metric Name: logs.events.count
-        ## Metric Type: COUNTER
+        B = data('log_entry_count', rollup='sum').sum(by=['severity'], allow_missing=['severity']).sum(over='1d').mean(over='7d').publish(label='Entry Count')
     EOF
     show_data_markers  = false
     show_event_lines   = false

--- a/dashboards-and-dashboard-groups/executive-dashboards/README.md
+++ b/dashboards-and-dashboard-groups/executive-dashboards/README.md
@@ -43,7 +43,7 @@ Metric Name: logs.events.count
 - Provides 4 week and 12 week comparisons of Log Observer usage
   - Logs received per day by token
   - Profiling logs received per day by token
-  - Logs per day by severity (requires setting up the [Log Observer metric](#log-observer-severity-metric) mentioned above)
+  - Logs per day by severity 
 
 
 ### Real User Monitoring (RUM) overview:
@@ -61,8 +61,8 @@ Metric Name: logs.events.count
   - RUM Workflow latency (p75)
 
 
-### Billing overview:
-- Provides 4 week and 12 week comparisons of "Billable Metrics"
+### License Usage overview:
+- Provides 4 week and 12 week comparisons of "License Metrics"
   - APM Hosts
   - APM Span Bytes Received
   - APM Troubleshooting Metric Sets
@@ -73,3 +73,15 @@ Metric Name: logs.events.count
   - IMM Data Points per Minute (DPM)
   - Log Observer ingest bytes
   - Log Observer ingest bytes per host
+  - Synthetics Datapoints Received
+
+
+### Token Usage overview:
+- Token Usage Rate 4 week and 12 week comparisons
+- MTS Token Usage 4 week and 12 week comparisons
+- Total MTS Usage by Token
+- Bundled Metrics by Token
+- Custom Metrics by Token
+- Resource Metrics by Token
+- APM Bundled Metrics by Token
+- Logs and Profiling Logs by Token

--- a/dashboards-and-dashboard-groups/executive-dashboards/README.md
+++ b/dashboards-and-dashboard-groups/executive-dashboards/README.md
@@ -8,26 +8,8 @@ Executive Dashboards in this group are focused on high level comparisons over ti
     ```
     api_url - (Optional) The API URL to use for communicating with SignalFx. This is helpful for organizations that need to set their Realm or use a proxy. You can also set it using the SFX_API_URL environment variable.
     ```
-- Log Events dashboards can be enriched with a Log Observer Metric noted below
 
 **Reminder:** These dashboards can be edited to include more context or split by dimensions specific to your own concerns. 
-
-
-## Log Observer Severity Metric
-Note: When using Log Observer Connect this metric will need to be metricized in Splunk Cloud.
-
-This metric enables visualizing log observer ingest by severity/log level.
-```
-Matching Condition: Match All
-
-Operation: count
-
-Dimensions: ["severity","deployment.environment"]
-(Replace "deployment.environment" with your environment dimension)
-
-Field: null
-
-Metric Name: logs.events.count
 
 ```
 

--- a/dashboards-and-dashboard-groups/executive-dashboards/RUM-Exec.tf
+++ b/dashboards-and-dashboard-groups/executive-dashboards/RUM-Exec.tf
@@ -648,7 +648,7 @@ resource "signalfx_list_chart" "RUM-Exec_7" {
 }
 # signalfx_list_chart.RUM-Exec_8:
 resource "signalfx_list_chart" "RUM-Exec_8" {
-    color_by                = "Dimension"
+    color_by                = "Metric"
     description             = "Workflow rate Top and Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -846,7 +846,7 @@ resource "signalfx_list_chart" "RUM-Exec_9" {
 }
 # signalfx_list_chart.RUM-Exec_10:
 resource "signalfx_list_chart" "RUM-Exec_10" {
-    color_by                = "Dimension"
+    color_by                = "Metric"
     description             = "Workflow latency change Top and Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false

--- a/dashboards-and-dashboard-groups/executive-dashboards/Token-Usage-Exec.tf
+++ b/dashboards-and-dashboard-groups/executive-dashboards/Token-Usage-Exec.tf
@@ -114,8 +114,8 @@ resource "signalfx_dashboard" "TOKEN-USAGE-EXEC" {
 
 # signalfx_list_chart.TOKEN-USAGE-EXEC_0:
 resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_0" {
-    color_by                = "Scale"
-    description             = "Token Usage Change Top and Bottom 5 (12 Week Comparison of  7 Day Means)"
+    color_by                = "Metric"
+    description             = "Token Usage Change Top and Bottom 5 (12 Week Comparison of 7 Day Means)"
     disable_sampling        = false
     hide_missing_values     = false
     max_precision           = 2
@@ -152,21 +152,6 @@ resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_0" {
     time_range              = 900
     timezone                = "UTC"
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "lime_green"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
-    color_scale {
-        color = "red"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
 
     legend_options_fields {
         enabled  = false
@@ -834,7 +819,7 @@ resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_8" {
 }
 # signalfx_list_chart.TOKEN-USAGE-EXEC_9:
 resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_9" {
-    color_by                = "Scale"
+    color_by                = "Metric"
     description             = "Logs Received per Day by Token 4 Week Comparison (7 Day Mean)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -851,21 +836,6 @@ resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_9" {
     time_range              = 900
     timezone                = "UTC"
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "aquamarine"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
-    color_scale {
-        color = "gray"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
 
     legend_options_fields {
         enabled  = false
@@ -901,7 +871,7 @@ resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_9" {
 }
 # signalfx_list_chart.TOKEN-USAGE-EXEC_10:
 resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_10" {
-    color_by                = "Scale"
+    color_by                = "Metric"
     description             = "Profiling Logs Received per Day by Token 4 Week Comparisons (7 Day Means)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -918,21 +888,6 @@ resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_10" {
     time_range              = 900
     timezone                = "UTC"
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "aquamarine"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
-    color_scale {
-        color = "gray"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
 
     legend_options_fields {
         enabled  = false

--- a/dashboards-and-dashboard-groups/executive-dashboards/Usage-Overview-Exec.tf
+++ b/dashboards-and-dashboard-groups/executive-dashboards/Usage-Overview-Exec.tf
@@ -773,7 +773,7 @@ resource "signalfx_list_chart" "License-Exec_11" {
         value_suffix = "%"
     }
     viz_options {
-        display_name = "Current Rum Span Bytes"
+        display_name = "Synthetics Datapoints Received"
         label        = "C"
     }
     viz_options {

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/APM_IMM-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/APM_IMM-Exec.tf
@@ -128,13 +128,13 @@ resource "signalfx_list_chart" "APM_IMM-Exec_0" {
         color        = "lilac"
         display_name = "Requests"
         label        = "A"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"
         display_name = "Requests(-4w)"
         label        = "B"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
 }
 # signalfx_list_chart.APM_IMM-Exec_1:
@@ -186,19 +186,19 @@ resource "signalfx_list_chart" "APM_IMM-Exec_1" {
         color        = "lilac"
         display_name = "-12w"
         label        = "E"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"
         display_name = "-4w"
         label        = "D"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"
         display_name = "Today"
         label        = "C"
-        value_suffix = "requests/s"
+        value_suffix = " "
     }
 }
 # signalfx_list_chart.APM_IMM-Exec_2:
@@ -256,13 +256,13 @@ resource "signalfx_list_chart" "APM_IMM-Exec_2" {
         color        = "lilac"
         display_name = "Requests"
         label        = "A"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"
         display_name = "Requests(-4w)"
         label        = "B"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
 }
 # signalfx_list_chart.APM_IMM-Exec_3:
@@ -332,13 +332,13 @@ resource "signalfx_list_chart" "APM_IMM-Exec_3" {
         color        = "lilac"
         display_name = "-12w"
         label        = "E"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"
         display_name = "-4w"
         label        = "D"
-        value_suffix = "requests/s"
+        value_suffix = "requests/m"
     }
     viz_options {
         color        = "lilac"

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/APM_IMM-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/APM_IMM-Exec.tf
@@ -93,7 +93,7 @@ resource "signalfx_dashboard" "APM_IMM-Exec" {
 
 # signalfx_list_chart.APM_IMM-Exec_0:
 resource "signalfx_list_chart" "APM_IMM-Exec_0" {
-    color_by                = "Scale"
+    color_by                = "Metric"
     description             = "Traffic Change Top and Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -111,21 +111,6 @@ resource "signalfx_list_chart" "APM_IMM-Exec_0" {
     sort_by                 = "-value"
     time_range              = 900
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "lime_green"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
-    color_scale {
-        color = "red"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
 
     viz_options {
         color        = "brown"
@@ -218,7 +203,7 @@ resource "signalfx_list_chart" "APM_IMM-Exec_1" {
 }
 # signalfx_list_chart.APM_IMM-Exec_2:
 resource "signalfx_list_chart" "APM_IMM-Exec_2" {
-    color_by                = "Scale"
+    color_by                = "Metric"
     description             = "Latency (P90) Top and Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -254,21 +239,6 @@ resource "signalfx_list_chart" "APM_IMM-Exec_2" {
     sort_by                 = "+value"
     time_range              = 900
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "lime_green"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
-    color_scale {
-        color = "red"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
 
     viz_options {
         color        = "aquamarine"
@@ -379,7 +349,7 @@ resource "signalfx_list_chart" "APM_IMM-Exec_3" {
 }
 # signalfx_list_chart.APM_IMM-Exec_4:
 resource "signalfx_list_chart" "APM_IMM-Exec_4" {
-    color_by                = "Scale"
+    color_by                = "Metric"
     description             = "Error rate Top and Bottom 5 (12 week comparison)"
     disable_sampling        = true
     hide_missing_values     = false
@@ -400,21 +370,6 @@ resource "signalfx_list_chart" "APM_IMM-Exec_4" {
     sort_by                 = "+value"
     time_range              = 900
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "lime_green"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
-    color_scale {
-        color = "red"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
 
     legend_options_fields {
         enabled  = false
@@ -544,7 +499,7 @@ resource "signalfx_list_chart" "APM_IMM-Exec_5" {
 }
 # signalfx_list_chart.APM_IMM-Exec_6:
 resource "signalfx_list_chart" "APM_IMM-Exec_6" {
-    color_by                = "Dimension"
+    color_by                = "Metric"
     description             = "Service Saturation of CPU/MEM/DISK Top and Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Logs-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Logs-Exec.tf
@@ -119,7 +119,7 @@ resource "signalfx_list_chart" "Logs-Exec_0" {
 }
 # signalfx_list_chart.Logs-Exec_1:
 resource "signalfx_list_chart" "Logs-Exec_1" {
-    color_by                = "Dimension"
+    color_by                = "Metric"
     description             = "Logs Received per Day by Token Top & Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -179,12 +179,13 @@ resource "signalfx_list_chart" "Logs-Exec_1" {
     }
 
     viz_options {
-        display_name = "D"
-        label        = "D"
+        display_name = "Log Events by Token (Top)"
+        label        = "C"
+        value_suffix = "%"
     }
     viz_options {
-        display_name = "Log Events by Token"
-        label        = "C"
+        display_name = "Log Events by Token (Bottom)"
+        label        = "D"
         value_suffix = "%"
     }
     viz_options {
@@ -256,7 +257,7 @@ resource "signalfx_list_chart" "Logs-Exec_2" {
 }
 # signalfx_list_chart.Logs-Exec_3:
 resource "signalfx_list_chart" "Logs-Exec_3" {
-    color_by                = "Dimension"
+    color_by                = "Metric"
     description             = "Logs Profiling Logs Received per Day by Token Top & Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -346,15 +347,7 @@ resource "signalfx_list_chart" "Logs-Exec_5" {
     name                    = "Events per Day by Log Level"
     program_text            = <<-EOF
         C = data('logs.events.count', rollup='sum').sum(by=['severity'], allow_missing=['severity']).mean(over='7d').sum(over='1d').publish(label='C')
-        
-        ### Relies on a Log Pipeline Management Metric
-        ### Setup with below information
-        ## Matching Condition: Match All
-        ## Operation: count
-        ## Dimensions: ["severity","deployment.environment"]
-        ## Field: null
-        ## Metric Name: logs.events.count
-        ## Metric Type: COUNTER
+        D = data('log_entry_count', rollup='sum').sum(by=['severity'], allow_missing=['severity']).mean(over='7d').sum(over='1d').publish(label='C')
     EOF
     secondary_visualization = "None"
     sort_by                 = "-value"
@@ -404,15 +397,10 @@ resource "signalfx_list_chart" "Logs-Exec_6" {
         A = data('logs.events.count').sum(by=['severity'], allow_missing=['severity']).mean(over='7d').sum(over='1d').publish(label='A', enable=False)
         B = data('logs.events.count').sum(by=['severity'], allow_missing=['severity']).timeshift('12w').mean(over='7d').sum(over='1d').publish(label='B', enable=False)
         C = (((A-B)/B)*100).mean(by=['severity'], allow_missing=['severity']).mean(over='7d').publish(label='C')
-        
-        ### Relies on a Log Pipeline Management Metric
-        ### Setup with below information
-        ## Matching Condition: Match All
-        ## Operation: count
-        ## Dimensions: ["severity","deployment.environment"]
-        ## Field: null
-        ## Metric Name: logs.events.count
-        ## Metric Type: COUNTER
+
+        D = data('log_entry_count').sum(by=['severity'], allow_missing=['severity']).mean(over='7d').sum(over='1d').publish(label='D', enable=False)
+        E = data('log_entry_count').sum(by=['severity'], allow_missing=['severity']).timeshift('12w').mean(over='7d').sum(over='1d').publish(label='E', enable=False)
+        F = (((D-E)/E)*100).mean(by=['severity'], allow_missing=['severity']).mean(over='7d').publish(label='F')
     EOF
     secondary_visualization = "None"
     sort_by                 = "-value"
@@ -462,6 +450,11 @@ resource "signalfx_list_chart" "Logs-Exec_6" {
         value_suffix = "%"
     }
     viz_options {
+        display_name = "F"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
         display_name = "rum.webvitals_fid.time.ns.p75 - Sum by sf_ua_browsername"
         label        = "A"
     }
@@ -483,15 +476,7 @@ resource "signalfx_time_chart" "Logs-Exec_7" {
     plot_type          = "AreaChart"
     program_text       = <<-EOF
         C = data('logs.events.count', rollup='sum').sum(by=['severity'], allow_missing=['severity']).sum(over='1d').mean(over='7d').publish(label='Event Count')
-        
-        ### Relies on a Log Pipeline Management Metric
-        ### Setup with below information
-        ## Matching Condition: Match All
-        ## Operation: count
-        ## Dimensions: ["severity","deployment.environment"]
-        ## Field: null
-        ## Metric Name: logs.events.count
-        ## Metric Type: COUNTER
+        B = data('log_entry_count', rollup='sum').sum(by=['severity'], allow_missing=['severity']).sum(over='1d').mean(over='7d').publish(label='Entry Count')
     EOF
     show_data_markers  = false
     show_event_lines   = false

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Logs-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Logs-Exec.tf
@@ -53,15 +53,8 @@ resource "signalfx_dashboard" "Logs-Exec" {
     chart {
         chart_id = signalfx_time_chart.Logs-Exec_7.id
         column   = 0
-        height   = 1
+        height   = 2
         row      = 3
-        width    = 6
-    }
-    chart {
-        chart_id = signalfx_text_chart.Logs-Exec_4.id
-        column   = 0
-        height   = 1
-        row      = 2
         width    = 6
     }
 
@@ -341,23 +334,6 @@ resource "signalfx_list_chart" "Logs-Exec_3" {
         label        = "B"
         value_unit   = "Millisecond"
     }
-}
-# signalfx_text_chart.Logs-Exec_4:
-resource "signalfx_text_chart" "Logs-Exec_4" {
-    markdown = <<-EOF
-        ###_Log Observer Events charts require this query_
-        ##### Note: Logs ingested with Log Observer Connect will need to be metricized in Splunk Cloud
-        
-        **Setup Log Pipeline Management Metric:**
-        ##### -Matching Condition: Match All
-        ##### -Operation: count
-        ##### -Dimensions: ["severity","deployment.environment"]
-        ###### (Replace "deployment.environment" with your environment dimension)
-        ##### -Field: null
-        ##### -Metric Name: logs.events.count
-        ##### -Metric Type: COUNTER
-    EOF
-    name     = "LO Events Query"
 }
 # signalfx_list_chart.Logs-Exec_5:
 resource "signalfx_list_chart" "Logs-Exec_5" {

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/RUM-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/RUM-Exec.tf
@@ -648,7 +648,7 @@ resource "signalfx_list_chart" "RUM-Exec_7" {
 }
 # signalfx_list_chart.RUM-Exec_8:
 resource "signalfx_list_chart" "RUM-Exec_8" {
-    color_by                = "Dimension"
+    color_by                = "Metric"
     description             = "Workflow rate Top and Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -846,7 +846,7 @@ resource "signalfx_list_chart" "RUM-Exec_9" {
 }
 # signalfx_list_chart.RUM-Exec_10:
 resource "signalfx_list_chart" "RUM-Exec_10" {
-    color_by                = "Dimension"
+    color_by                = "Metric"
     description             = "Workflow latency change Top and Bottom 5 (12 week comparison)"
     disable_sampling        = false
     hide_missing_values     = false

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Token-Usage-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Token-Usage-Exec.tf
@@ -114,8 +114,8 @@ resource "signalfx_dashboard" "TOKEN-USAGE-EXEC" {
 
 # signalfx_list_chart.TOKEN-USAGE-EXEC_0:
 resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_0" {
-    color_by                = "Scale"
-    description             = "Token Usage Change Top and Bottom 5 (12 Week Comparison of  7 Day Means)"
+    color_by                = "Metric"
+    description             = "Token Usage Change Top and Bottom 5 (12 Week Comparison of 7 Day Means)"
     disable_sampling        = false
     hide_missing_values     = false
     max_precision           = 2
@@ -152,21 +152,6 @@ resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_0" {
     time_range              = 900
     timezone                = "UTC"
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "lime_green"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
-    color_scale {
-        color = "red"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
 
     legend_options_fields {
         enabled  = false
@@ -834,7 +819,7 @@ resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_8" {
 }
 # signalfx_list_chart.TOKEN-USAGE-EXEC_9:
 resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_9" {
-    color_by                = "Scale"
+    color_by                = "Metric"
     description             = "Logs Received per Day by Token 4 Week Comparison (7 Day Mean)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -851,21 +836,6 @@ resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_9" {
     time_range              = 900
     timezone                = "UTC"
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "aquamarine"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
-    color_scale {
-        color = "gray"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
 
     legend_options_fields {
         enabled  = false
@@ -901,7 +871,7 @@ resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_9" {
 }
 # signalfx_list_chart.TOKEN-USAGE-EXEC_10:
 resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_10" {
-    color_by                = "Scale"
+    color_by                = "Metric"
     description             = "Profiling Logs Received per Day by Token 4 Week Comparisons (7 Day Means)"
     disable_sampling        = false
     hide_missing_values     = false
@@ -918,21 +888,6 @@ resource "signalfx_list_chart" "TOKEN-USAGE-EXEC_10" {
     time_range              = 900
     timezone                = "UTC"
     unit_prefix             = "Metric"
-
-    color_scale {
-        color = "aquamarine"
-        gt    = 340282346638528860000000000000000000000
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 0
-    }
-    color_scale {
-        color = "gray"
-        gt    = 0
-        gte   = 340282346638528860000000000000000000000
-        lt    = 340282346638528860000000000000000000000
-        lte   = 340282346638528860000000000000000000000
-    }
 
     legend_options_fields {
         enabled  = false

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Usage-Overview-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Usage-Overview-Exec.tf
@@ -1,96 +1,96 @@
-# signalfx_dashboard.Billing-Exec:
-resource "signalfx_dashboard" "Billing-Exec" {
+# signalfx_dashboard.License-Exec:
+resource "signalfx_dashboard" "Usage-Overview-Exec" {
     depends_on = [signalfx_dashboard.RUM-Exec]
     charts_resolution = "default"
     dashboard_group   = signalfx_dashboard_group.exec_dashboard_group.id
-    description       = "Executive Level Dashboard for Billing Metrics"
-    name              = "Billing - Exec"
+    description       = "Executive Level Dashboard for Overall Usage Metrics"
+    name              = "License Usage Overview - Exec"
     time_range        = "-12w"
 
     chart {
-        chart_id = signalfx_list_chart.Billing-Exec_10.id
-        column   = 6
-        height   = 2
-        row      = 4
-        width    = 3
-    }
-    chart {
-        chart_id = signalfx_list_chart.Billing-Exec_8.id
-        column   = 0
-        height   = 2
-        row      = 4
-        width    = 3
-    }
-    chart {
-        chart_id = signalfx_list_chart.Billing-Exec_9.id
-        column   = 3
-        height   = 2
-        row      = 4
-        width    = 3
-    }
-    chart {
-        chart_id = signalfx_list_chart.Billing-Exec_2.id
-        column   = 6
-        height   = 2
-        row      = 0
-        width    = 3
-    }
-    chart {
-        chart_id = signalfx_list_chart.Billing-Exec_0.id
-        column   = 0
-        height   = 2
-        row      = 0
-        width    = 3
-    }
-    chart {
-        chart_id = signalfx_list_chart.Billing-Exec_4.id
-        column   = 0
-        height   = 2
-        row      = 2
-        width    = 3
-    }
-    chart {
-        chart_id = signalfx_list_chart.Billing-Exec_5.id
-        column   = 3
-        height   = 2
-        row      = 2
-        width    = 3
-    }
-    chart {
-        chart_id = signalfx_list_chart.Billing-Exec_6.id
-        column   = 6
-        height   = 2
-        row      = 2
-        width    = 3
-    }
-    chart {
-        chart_id = signalfx_list_chart.Billing-Exec_7.id
+        chart_id = signalfx_list_chart.License-Exec_10.id
         column   = 9
         height   = 2
         row      = 2
         width    = 3
     }
     chart {
-        chart_id = signalfx_list_chart.Billing-Exec_3.id
+        chart_id = signalfx_list_chart.License-Exec_8.id
+        column   = 0
+        height   = 2
+        row      = 4
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.License-Exec_9.id
+        column   = 3
+        height   = 2
+        row      = 4
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.License-Exec_2.id
+        column   = 6
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.License-Exec_0.id
+        column   = 0
+        height   = 2
+        row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.License-Exec_4.id
+        column   = 0
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.License-Exec_5.id
+        column   = 3
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.License-Exec_7.id
+        column   = 6
+        height   = 2
+        row      = 2
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.License-Exec_3.id
         column   = 9
         height   = 2
         row      = 0
         width    = 3
     }
     chart {
-        chart_id = signalfx_list_chart.Billing-Exec_1.id
+        chart_id = signalfx_list_chart.License-Exec_1.id
         column   = 3
         height   = 2
         row      = 0
+        width    = 3
+    }
+    chart {
+        chart_id = signalfx_list_chart.License-Exec_11.id
+        column   = 6
+        height   = 2
+        row      = 4
         width    = 3
     }
 
 }
 
-# signalfx_list_chart.Billing-Exec_0:
-resource "signalfx_list_chart" "Billing-Exec_0" {
+# signalfx_list_chart.License-Exec_0:
+resource "signalfx_list_chart" "License-Exec_0" {
     color_by                = "Dimension"
-    description             = "APM - Hosts Billing metric (7 day avg)"
+    description             = "APM - Hosts License metric (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -153,10 +153,10 @@ resource "signalfx_list_chart" "Billing-Exec_0" {
         label        = "H"
     }
 }
-# signalfx_list_chart.Billing-Exec_1:
-resource "signalfx_list_chart" "Billing-Exec_1" {
+# signalfx_list_chart.License-Exec_1:
+resource "signalfx_list_chart" "License-Exec_1" {
     color_by                = "Dimension"
-    description             = "APM - TPM Span Bytes Billing metric"
+    description             = "APM - TPM Span Bytes License metric"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -210,10 +210,10 @@ resource "signalfx_list_chart" "Billing-Exec_1" {
         label        = "E"
     }
 }
-# signalfx_list_chart.Billing-Exec_2:
-resource "signalfx_list_chart" "Billing-Exec_2" {
+# signalfx_list_chart.License-Exec_2:
+resource "signalfx_list_chart" "License-Exec_2" {
     color_by                = "Dimension"
-    description             = "APM - TPM Troubleshooting Metric Sets Billing metric (7 day avg)"
+    description             = "APM - TPM Troubleshooting Metric Sets License metric (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -266,10 +266,10 @@ resource "signalfx_list_chart" "Billing-Exec_2" {
         label        = "E"
     }
 }
-# signalfx_list_chart.Billing-Exec_3:
-resource "signalfx_list_chart" "Billing-Exec_3" {
+# signalfx_list_chart.License-Exec_3:
+resource "signalfx_list_chart" "License-Exec_3" {
     color_by                = "Dimension"
-    description             = "APM - TPM Traces Billing metric (7 day avg)"
+    description             = "APM - TPM Traces License metric (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -322,10 +322,10 @@ resource "signalfx_list_chart" "Billing-Exec_3" {
         label        = "E"
     }
 }
-# signalfx_list_chart.Billing-Exec_4:
-resource "signalfx_list_chart" "Billing-Exec_4" {
+# signalfx_list_chart.License-Exec_4:
+resource "signalfx_list_chart" "License-Exec_4" {
     color_by                = "Dimension"
-    description             = "IMM - Hosts Billing metric (7 day avg)"
+    description             = "IMM - Hosts License metric (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -392,10 +392,10 @@ resource "signalfx_list_chart" "Billing-Exec_4" {
         label        = "H"
     }
 }
-# signalfx_list_chart.Billing-Exec_5:
-resource "signalfx_list_chart" "Billing-Exec_5" {
+# signalfx_list_chart.License-Exec_5:
+resource "signalfx_list_chart" "License-Exec_5" {
     color_by                = "Dimension"
-    description             = "IMM - Custom Metrics Billing metric (7 day avg)"
+    description             = "IMM - Custom Metrics License metric (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -448,66 +448,10 @@ resource "signalfx_list_chart" "Billing-Exec_5" {
         label        = "E"
     }
 }
-# signalfx_list_chart.Billing-Exec_6:
-resource "signalfx_list_chart" "Billing-Exec_6" {
+# signalfx_list_chart.License-Exec_7:
+resource "signalfx_list_chart" "License-Exec_7" {
     color_by                = "Dimension"
-    description             = "IMM - High Resolution Metrics Billing metric (7 day avg)"
-    disable_sampling        = false
-    hide_missing_values     = false
-    max_delay               = 0
-    max_precision           = 2
-    name                    = "IMM - High Resolution Metrics"
-    program_text            = <<-EOF
-        C = data('sf.org.numHighResolutionMetrics').mean(over='7d').publish(label='C')
-        D = data('sf.org.numHighResolutionMetrics').mean(over='7d').timeshift('4w').publish(label='D', enable=False)
-        E = data('sf.org.numHighResolutionMetrics').mean(over='7d').timeshift('12w').publish(label='E', enable=False)
-        F = (((C-D)/D)*100).publish(label='F')
-        G = (((C-E)/E)*100).publish(label='G')
-    EOF
-    secondary_visualization = "None"
-    time_range              = 900
-    unit_prefix             = "Metric"
-
-    legend_options_fields {
-        enabled  = false
-        property = "sf_originatingMetric"
-    }
-    legend_options_fields {
-        enabled  = false
-        property = "orgId"
-    }
-    legend_options_fields {
-        enabled  = true
-        property = "sf_metric"
-    }
-
-    viz_options {
-        display_name = "12 Week Comparison"
-        label        = "G"
-        value_suffix = "%"
-    }
-    viz_options {
-        display_name = "4 Week Comparison"
-        label        = "F"
-        value_suffix = "%"
-    }
-    viz_options {
-        display_name = "Current High Resolution Metrics"
-        label        = "C"
-    }
-    viz_options {
-        display_name = "D"
-        label        = "D"
-    }
-    viz_options {
-        display_name = "E"
-        label        = "E"
-    }
-}
-# signalfx_list_chart.Billing-Exec_7:
-resource "signalfx_list_chart" "Billing-Exec_7" {
-    color_by                = "Dimension"
-    description             = "IMM - Data Points Per Minute Billing metric (7 day avg)"
+    description             = "IMM - Data Points Per Minute License metric (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -568,10 +512,10 @@ resource "signalfx_list_chart" "Billing-Exec_7" {
         label        = "E"
     }
 }
-# signalfx_list_chart.Billing-Exec_8:
-resource "signalfx_list_chart" "Billing-Exec_8" {
+# signalfx_list_chart.License-Exec_8:
+resource "signalfx_list_chart" "License-Exec_8" {
     color_by                = "Dimension"
-    description             = "Logs - Ingest Bytes Billing metric (7 day avg)"
+    description             = "Logs - Ingest Bytes License metric (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -631,10 +575,10 @@ resource "signalfx_list_chart" "Billing-Exec_8" {
         value_unit   = "Byte"
     }
 }
-# signalfx_list_chart.Billing-Exec_9:
-resource "signalfx_list_chart" "Billing-Exec_9" {
+# signalfx_list_chart.License-Exec_9:
+resource "signalfx_list_chart" "License-Exec_9" {
     color_by                = "Dimension"
-    description             = "Logs - Per Host Ingest Bytes Billing metric (7 day avg)"
+    description             = "Logs - Per Host Ingest Bytes License metric (7 day avg)"
     disable_sampling        = false
     hide_missing_values     = false
     max_delay               = 0
@@ -709,8 +653,8 @@ resource "signalfx_list_chart" "Billing-Exec_9" {
         label        = "H"
     }
 }
-# signalfx_list_chart.Billing-Exec_10:
-resource "signalfx_list_chart" "Billing-Exec_10" {
+# signalfx_list_chart.License-Exec_10:
+resource "signalfx_list_chart" "License-Exec_10" {
     color_by                = "Dimension"
     description             = "RUM/APM - RUM Span Bytes (7 day avg)"
     disable_sampling        = false
@@ -774,5 +718,70 @@ resource "signalfx_list_chart" "Billing-Exec_10" {
         display_name = "E"
         label        = "E"
         value_unit   = "Byte"
+    }
+}
+
+# signalfx_list_chart.License-Exec_11:
+resource "signalfx_list_chart" "License-Exec_11" {
+    color_by                = "Dimension"
+    description             = "Synthetics - Datapoints Received (7 day avg)"
+    disable_sampling        = false
+    hide_missing_values     = false
+    max_delay               = 0
+    max_precision           = 2
+    name                    = "Synthetics - Datapoints Received"
+    program_text            = <<-EOF
+        F = (((C-D)/D)*100).publish(label='F')
+        G = (((C-E)/E)*100).publish(label='G')
+        D = data('sf.org.synthetics.numDatapointsReceived').sum().mean(over='7d').timeshift('4w').publish(label='D', enable=False)
+        E = data('sf.org.synthetics.numDatapointsReceived').sum().mean(over='7d').timeshift('12w').publish(label='E', enable=False)
+        C = data('sf.org.synthetics.numDatapointsReceived').sum().mean(over='7d').publish(label='C')
+    EOF
+    secondary_visualization = "None"
+    time_range              = 900
+    unit_prefix             = "Metric"
+
+    legend_options_fields {
+        enabled  = false
+        property = "sf_originatingMetric"
+    }
+    legend_options_fields {
+        enabled  = false
+        property = "orgId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "sf_metric"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "tokenId"
+    }
+    legend_options_fields {
+        enabled  = true
+        property = "category"
+    }
+
+    viz_options {
+        display_name = "12 Week Comparison"
+        label        = "G"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "4 Week Comparison"
+        label        = "F"
+        value_suffix = "%"
+    }
+    viz_options {
+        display_name = "Current Rum Span Bytes"
+        label        = "C"
+    }
+    viz_options {
+        display_name = "D"
+        label        = "D"
+    }
+    viz_options {
+        display_name = "E"
+        label        = "E"
     }
 }

--- a/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Usage-Overview-Exec.tf
+++ b/integration-examples/terraform-jumpstart/modules/dashboards/executive-dashboards/Usage-Overview-Exec.tf
@@ -773,7 +773,7 @@ resource "signalfx_list_chart" "License-Exec_11" {
         value_suffix = "%"
     }
     viz_options {
-        display_name = "Current Rum Span Bytes"
+        display_name = "Synthetics Datapoints Received"
         label        = "C"
     }
     viz_options {


### PR DESCRIPTION
- Fix coloring to Top and Bottom on charts with top5/bottom5 to make that more obvious
- Add additional metric name `log_entry_count` for LOC
- Remove documentation of metrics from old Log Observer
- Update README