### PR TITLE
OpenTelemetry Receiver to Splunk Observability dashboard generator (Terraform configs)

### DIFF
--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/.gitignore
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/.gitignore
@@ -1,0 +1,195 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/README.md
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/README.md
@@ -13,7 +13,7 @@ python3 otel-dashboard-o11y.py --file_path ./metadata.yaml
 ## Generate dashboards for many receivers
 If the `--file_path` argument is not used the script will look in the local directory [`./otel-receiver-yaml/`](./otel-receiver-yaml/) for available receiver `metadata.yaml` files with metrics sections. Generated Terraform configurations will be placed in the local directory [`./observability-tf-configs`](./observability-tf-configs/).
 
-`pull-otel-yaml.py` can be used to pull down all [receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver) configs with a `metrics` section and place them in the `./otel-receiver-yaml` directory. 
+`pull-otel-yaml.py` can be used to pull down all [receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver) configs with a `metrics` section and place them in the `./otel-receiver-yaml` directory. To avoid api rate limiting during this process a Github PAT token can be provided with the environment variable `$GITHUB_PAT_TOKEN`.
 ```
 pip3 install -r requirements.txt
 python3 pull-otel-yaml.py                          

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/README.md
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/README.md
@@ -1,0 +1,55 @@
+# Generate Splunk Observability Dashboards from OpenTelemetry Receivers
+These scripts help users of OpenTelemetry Receivers from the [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/) generate Terraform configurations of Splunk Observability dashboards from OpenTelemetry Receiver `metadata.yaml` files that contain the receiver's available metrics.
+
+## Generate dashboard for a single receiver
+Install the requirements and run `otel-dashboard-o11y.py` with the `--file_path` option pointing the `metadata.yaml` file for the receiver you'd like to generate from. 
+
+Note: The Terraform configuration will print to STDOUT which can be piped to a `.tf` file. 
+```
+pip3 install -r requirements.txt
+python3 otel-dashboard-o11y.py --file_path ./metadata.yaml
+```
+
+## Generate dashboards for many receivers
+If the `--file_path` argument is not used the script will look in the local directory [`./otel-receiver-yaml/`](./otel-receiver-yaml/) for available receiver `metadata.yaml` files with metrics sections. Generated Terraform configurations will be placed in the local directory [`./observability-tf-configs`](./observability-tf-configs/).
+
+`pull-otel-yaml.py` can be used to pull down all [receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver) configs with a `metrics` section and place them in the `./otel-receiver-yaml` directory. 
+```
+pip3 install -r requirements.txt
+python3 pull-otel-yaml.py                          
+
+Metadata.yaml with 'metrics' section extracted from activedirectorydsreceiver
+Metadata.yaml with 'metrics' section extracted from aerospikereceiver
+...
+```
+
+## Terraform Configuration Considerations
+**NOTE:** These generated dashboards are not a replacement for any of the Out Of The Box dashboards available in Splunk Observability. [A list of those dashboards is available here](https://docs.splunk.com/observability/en/data-visualization/dashboards/dashboards-list.html). Using the out of the box dashboards will most likely provide the best monitoring experience for a given technology.
+
+Generated Terraform configurations are just that... Generated. They include a line chart per metric named for that metric in a dashboard named for the receiver.
+
+When generating a large number of configs there may be duplicate resource names in `terraform plan` based on metrics that use the same name. In this case edit the duplicate resource name and re-run `terraform plan`
+
+### Terraform `signalfx` Provider
+All generated configs work with the [`signalfx`]() Terraform provider. You'll need to define the provider in a `.tf` file in the same directory as your generated configurations.
+
+**Example Provider configuration:** edit to incude your `api_url` and `$SFX_AUTH_TOKEN` for your specific Observability api url and api token.
+```
+terraform {
+  required_providers {
+    signalfx = {
+      version = "~> 9.0.0"
+      source  = "splunk-terraform/signalfx"
+    }
+  }
+}
+
+# Configure the SignalFx provider
+provider "signalfx" {
+  auth_token = "${var.SFX_AUTH_TOKEN}"
+  # If your organization uses a different realm
+  api_url = "https://api.us1.signalfx.com"
+  # If your organization uses a custom URL
+  # custom_app_url = "https://myorg.signalfx.com"
+}
+```

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/activedirectorydsreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/activedirectorydsreceiver_metadata.yaml.tf
@@ -1,0 +1,270 @@
+
+resource "signalfx_dashboard" "active_directory_dsdashboard" {
+  name            = "active_directory_ds"
+  dashboard_group = signalfx_dashboard_group.active_directory_dsdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.active_directory_ds_replication_network_io.id, signalfx_time_chart.active_directory_ds_replication_sync_object_pending.id, signalfx_time_chart.active_directory_ds_replication_sync_request_count.id, signalfx_time_chart.active_directory_ds_replication_object_rate.id, signalfx_time_chart.active_directory_ds_replication_property_rate.id, signalfx_time_chart.active_directory_ds_replication_value_rate.id, signalfx_time_chart.active_directory_ds_replication_operation_pending.id, signalfx_time_chart.active_directory_ds_operation_rate.id, signalfx_time_chart.active_directory_ds_name_cache_hit_rate.id, signalfx_time_chart.active_directory_ds_notification_queued.id, signalfx_time_chart.active_directory_ds_security_descriptor_propagations_event_queued.id, signalfx_time_chart.active_directory_ds_suboperation_rate.id, signalfx_time_chart.active_directory_ds_bind_rate.id, signalfx_time_chart.active_directory_ds_thread_count.id, signalfx_time_chart.active_directory_ds_ldap_client_session_count.id, signalfx_time_chart.active_directory_ds_ldap_bind_last_successful_time.id, signalfx_time_chart.active_directory_ds_ldap_bind_rate.id, signalfx_time_chart.active_directory_ds_ldap_search_rate.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "active_directory_dsdashboardgroup0" {
+  name        = "active_directory_ds generated OTel dashboard group"
+  description = "active_directory_ds generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "active_directory_ds_replication_network_io" {
+  name = "The amount of network data transmitted by the Directory Replication Agent."
+
+  program_text = <<-EOF
+    data("active_directory.ds.replication.network.io").publish(label="The amount of network data transmitted by the Directory Replication Agent.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_replication_sync_object_pending" {
+  name = "The number of objects remaining until the full sync completes for the Directory Replication Agent."
+
+  program_text = <<-EOF
+    data("active_directory.ds.replication.sync.object.pending").publish(label="The number of objects remaining until the full sync completes for the Directory Replication Agent.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_replication_sync_request_count" {
+  name = "The number of sync requests made by the Directory Replication Agent."
+
+  program_text = <<-EOF
+    data("active_directory.ds.replication.sync.request.count").publish(label="The number of sync requests made by the Directory Replication Agent.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_replication_object_rate" {
+  name = "The number of objects transmitted by the Directory Replication Agent per second."
+
+  program_text = <<-EOF
+    data("active_directory.ds.replication.object.rate").publish(label="The number of objects transmitted by the Directory Replication Agent per second.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_replication_property_rate" {
+  name = "The number of properties transmitted by the Directory Replication Agent per second."
+
+  program_text = <<-EOF
+    data("active_directory.ds.replication.property.rate").publish(label="The number of properties transmitted by the Directory Replication Agent per second.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_replication_value_rate" {
+  name = "The number of values transmitted by the Directory Replication Agent per second."
+
+  program_text = <<-EOF
+    data("active_directory.ds.replication.value.rate").publish(label="The number of values transmitted by the Directory Replication Agent per second.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_replication_operation_pending" {
+  name = "The number of pending replication operations for the Directory Replication Agent."
+
+  program_text = <<-EOF
+    data("active_directory.ds.replication.operation.pending").publish(label="The number of pending replication operations for the Directory Replication Agent.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_operation_rate" {
+  name = "The number of operations performed per second."
+
+  program_text = <<-EOF
+    data("active_directory.ds.operation.rate").publish(label="The number of operations performed per second.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_name_cache_hit_rate" {
+  name = "The percentage of directory object name component lookups that are satisfied by the Directory System Agent's name cache."
+
+  program_text = <<-EOF
+    data("active_directory.ds.name_cache.hit_rate").publish(label="The percentage of directory object name component lookups that are satisfied by the Directory System Agent's name cache.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_notification_queued" {
+  name = "The number of pending update notifications that have been queued to push to clients."
+
+  program_text = <<-EOF
+    data("active_directory.ds.notification.queued").publish(label="The number of pending update notifications that have been queued to push to clients.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_security_descriptor_propagations_event_queued" {
+  name = "The number of security descriptor propagation events that are queued for processing."
+
+  program_text = <<-EOF
+    data("active_directory.ds.security_descriptor_propagations_event.queued").publish(label="The number of security descriptor propagation events that are queued for processing.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_suboperation_rate" {
+  name = "The rate of sub-operations performed."
+
+  program_text = <<-EOF
+    data("active_directory.ds.suboperation.rate").publish(label="The rate of sub-operations performed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_bind_rate" {
+  name = "The number of binds per second serviced by this domain controller."
+
+  program_text = <<-EOF
+    data("active_directory.ds.bind.rate").publish(label="The number of binds per second serviced by this domain controller.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_thread_count" {
+  name = "The number of threads in use by the directory service."
+
+  program_text = <<-EOF
+    data("active_directory.ds.thread.count").publish(label="The number of threads in use by the directory service.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_ldap_client_session_count" {
+  name = "The number of connected LDAP client sessions."
+
+  program_text = <<-EOF
+    data("active_directory.ds.ldap.client.session.count").publish(label="The number of connected LDAP client sessions.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_ldap_bind_last_successful_time" {
+  name = "The amount of time taken for the last successful LDAP bind."
+
+  program_text = <<-EOF
+    data("active_directory.ds.ldap.bind.last_successful.time").publish(label="The amount of time taken for the last successful LDAP bind.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_ldap_bind_rate" {
+  name = "The number of successful LDAP binds per second."
+
+  program_text = <<-EOF
+    data("active_directory.ds.ldap.bind.rate").publish(label="The number of successful LDAP binds per second.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "active_directory_ds_ldap_search_rate" {
+  name = "The number of LDAP searches per second."
+
+  program_text = <<-EOF
+    data("active_directory.ds.ldap.search.rate").publish(label="The number of LDAP searches per second.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/aerospikereceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/aerospikereceiver_metadata.yaml.tf
@@ -1,0 +1,214 @@
+
+resource "signalfx_dashboard" "aerospikedashboard" {
+  name            = "aerospike"
+  dashboard_group = signalfx_dashboard_group.aerospikedashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.aerospike_node_memory_free.id, signalfx_time_chart.aerospike_node_connection_count.id, signalfx_time_chart.aerospike_node_connection_open.id, signalfx_time_chart.aerospike_node_query_tracked.id, signalfx_time_chart.aerospike_namespace_memory_usage.id, signalfx_time_chart.aerospike_namespace_memory_free.id, signalfx_time_chart.aerospike_namespace_disk_available.id, signalfx_time_chart.aerospike_namespace_scan_count.id, signalfx_time_chart.aerospike_namespace_query_count.id, signalfx_time_chart.aerospike_namespace_geojson_region_query_cells.id, signalfx_time_chart.aerospike_namespace_geojson_region_query_false_positive.id, signalfx_time_chart.aerospike_namespace_geojson_region_query_points.id, signalfx_time_chart.aerospike_namespace_geojson_region_query_requests.id, signalfx_time_chart.aerospike_namespace_transaction_count.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "aerospikedashboardgroup0" {
+  name        = "aerospike generated OTel dashboard group"
+  description = "aerospike generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "aerospike_node_memory_free" {
+  name = "Percentage of the node's memory which is still free"
+
+  program_text = <<-EOF
+    data("aerospike.node.memory.free").publish(label="Percentage of the node's memory which is still free")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_node_connection_count" {
+  name = "Number of connections opened and closed to the node"
+
+  program_text = <<-EOF
+    data("aerospike.node.connection.count").publish(label="Number of connections opened and closed to the node")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_node_connection_open" {
+  name = "Current number of open connections to the node"
+
+  program_text = <<-EOF
+    data("aerospike.node.connection.open").publish(label="Current number of open connections to the node")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_node_query_tracked" {
+  name = "Number of queries tracked by the system."
+
+  program_text = <<-EOF
+    data("aerospike.node.query.tracked").publish(label="Number of queries tracked by the system.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_namespace_memory_usage" {
+  name = "Memory currently used by each component of the namespace"
+
+  program_text = <<-EOF
+    data("aerospike.namespace.memory.usage").publish(label="Memory currently used by each component of the namespace")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_namespace_memory_free" {
+  name = "Percentage of the namespace's memory which is still free"
+
+  program_text = <<-EOF
+    data("aerospike.namespace.memory.free").publish(label="Percentage of the namespace's memory which is still free")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_namespace_disk_available" {
+  name = "Minimum percentage of contiguous disk space free to the namespace across all devices"
+
+  program_text = <<-EOF
+    data("aerospike.namespace.disk.available").publish(label="Minimum percentage of contiguous disk space free to the namespace across all devices")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_namespace_scan_count" {
+  name = "Number of scan operations performed on the namespace"
+
+  program_text = <<-EOF
+    data("aerospike.namespace.scan.count").publish(label="Number of scan operations performed on the namespace")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_namespace_query_count" {
+  name = "Number of query operations performed on the namespace"
+
+  program_text = <<-EOF
+    data("aerospike.namespace.query.count").publish(label="Number of query operations performed on the namespace")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_namespace_geojson_region_query_cells" {
+  name = "Number of cell coverings for query region queried"
+
+  program_text = <<-EOF
+    data("aerospike.namespace.geojson.region_query_cells").publish(label="Number of cell coverings for query region queried")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_namespace_geojson_region_query_false_positive" {
+  name = "Number of points outside the region."
+
+  program_text = <<-EOF
+    data("aerospike.namespace.geojson.region_query_false_positive").publish(label="Number of points outside the region.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_namespace_geojson_region_query_points" {
+  name = "Number of points within the region."
+
+  program_text = <<-EOF
+    data("aerospike.namespace.geojson.region_query_points").publish(label="Number of points within the region.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_namespace_geojson_region_query_requests" {
+  name = "Number of geojson queries on the system since the uptime of the node."
+
+  program_text = <<-EOF
+    data("aerospike.namespace.geojson.region_query_requests").publish(label="Number of geojson queries on the system since the uptime of the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "aerospike_namespace_transaction_count" {
+  name = "Number of transactions performed on the namespace"
+
+  program_text = <<-EOF
+    data("aerospike.namespace.transaction.count").publish(label="Number of transactions performed on the namespace")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/apachereceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/apachereceiver_metadata.yaml.tf
@@ -1,0 +1,186 @@
+
+resource "signalfx_dashboard" "apachedashboard" {
+  name            = "apache"
+  dashboard_group = signalfx_dashboard_group.apachedashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.apache_uptime.id, signalfx_time_chart.apache_current_connections.id, signalfx_time_chart.apache_workers.id, signalfx_time_chart.apache_requests.id, signalfx_time_chart.apache_traffic.id, signalfx_time_chart.apache_cpu_time.id, signalfx_time_chart.apache_cpu_load.id, signalfx_time_chart.apache_load_1.id, signalfx_time_chart.apache_load_5.id, signalfx_time_chart.apache_load_15.id, signalfx_time_chart.apache_request_time.id, signalfx_time_chart.apache_scoreboard.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "apachedashboardgroup0" {
+  name        = "apache generated OTel dashboard group"
+  description = "apache generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "apache_uptime" {
+  name = "The amount of time that the server has been running in seconds."
+
+  program_text = <<-EOF
+    data("apache.uptime").publish(label="The amount of time that the server has been running in seconds.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_current_connections" {
+  name = "The number of active connections currently attached to the HTTP server."
+
+  program_text = <<-EOF
+    data("apache.current_connections").publish(label="The number of active connections currently attached to the HTTP server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_workers" {
+  name = "The number of workers currently attached to the HTTP server."
+
+  program_text = <<-EOF
+    data("apache.workers").publish(label="The number of workers currently attached to the HTTP server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_requests" {
+  name = "The number of requests serviced by the HTTP server per second."
+
+  program_text = <<-EOF
+    data("apache.requests").publish(label="The number of requests serviced by the HTTP server per second.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_traffic" {
+  name = "Total HTTP server traffic."
+
+  program_text = <<-EOF
+    data("apache.traffic").publish(label="Total HTTP server traffic.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_cpu_time" {
+  name = "Jiffs used by processes of given category."
+
+  program_text = <<-EOF
+    data("apache.cpu.time").publish(label="Jiffs used by processes of given category.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_cpu_load" {
+  name = "Current load of the CPU."
+
+  program_text = <<-EOF
+    data("apache.cpu.load").publish(label="Current load of the CPU.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_load_1" {
+  name = "The average server load during the last minute."
+
+  program_text = <<-EOF
+    data("apache.load.1").publish(label="The average server load during the last minute.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_load_5" {
+  name = "The average server load during the last 5 minutes."
+
+  program_text = <<-EOF
+    data("apache.load.5").publish(label="The average server load during the last 5 minutes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_load_15" {
+  name = "The average server load during the last 15 minutes."
+
+  program_text = <<-EOF
+    data("apache.load.15").publish(label="The average server load during the last 15 minutes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_request_time" {
+  name = "Total time spent on handling requests."
+
+  program_text = <<-EOF
+    data("apache.request.time").publish(label="Total time spent on handling requests.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "apache_scoreboard" {
+  name = "The number of workers in each state."
+
+  program_text = <<-EOF
+    data("apache.scoreboard").publish(label="The number of workers in each state.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/apachesparkreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/apachesparkreceiver_metadata.yaml.tf
@@ -1,0 +1,900 @@
+
+resource "signalfx_dashboard" "apachesparkdashboard" {
+  name            = "apachespark"
+  dashboard_group = signalfx_dashboard_group.apachesparkdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.spark_stage_status.id, signalfx_time_chart.spark_stage_task_active.id, signalfx_time_chart.spark_stage_task_result.id, signalfx_time_chart.spark_stage_executor_run_time.id, signalfx_time_chart.spark_stage_executor_cpu_time.id, signalfx_time_chart.spark_stage_task_result_size.id, signalfx_time_chart.spark_stage_jvm_gc_time.id, signalfx_time_chart.spark_stage_memory_spilled.id, signalfx_time_chart.spark_stage_disk_spilled.id, signalfx_time_chart.spark_stage_memory_peak.id, signalfx_time_chart.spark_stage_io_size.id, signalfx_time_chart.spark_stage_io_records.id, signalfx_time_chart.spark_stage_shuffle_blocks_fetched.id, signalfx_time_chart.spark_stage_shuffle_fetch_wait_time.id, signalfx_time_chart.spark_stage_shuffle_io_disk.id, signalfx_time_chart.spark_stage_shuffle_io_read_size.id, signalfx_time_chart.spark_stage_shuffle_io_write_size.id, signalfx_time_chart.spark_stage_shuffle_io_records.id, signalfx_time_chart.spark_stage_shuffle_write_time.id, signalfx_time_chart.spark_executor_memory_usage.id, signalfx_time_chart.spark_executor_disk_usage.id, signalfx_time_chart.spark_executor_task_limit.id, signalfx_time_chart.spark_executor_task_active.id, signalfx_time_chart.spark_executor_task_result.id, signalfx_time_chart.spark_executor_time.id, signalfx_time_chart.spark_executor_gc_time.id, signalfx_time_chart.spark_executor_input_size.id, signalfx_time_chart.spark_executor_shuffle_io_size.id, signalfx_time_chart.spark_executor_storage_memory_usage.id, signalfx_time_chart.spark_job_task_active.id, signalfx_time_chart.spark_job_task_result.id, signalfx_time_chart.spark_job_stage_active.id, signalfx_time_chart.spark_job_stage_result.id, signalfx_time_chart.spark_driver_block_manager_disk_usage.id, signalfx_time_chart.spark_driver_block_manager_memory_usage.id, signalfx_time_chart.spark_driver_hive_external_catalog_file_cache_hits.id, signalfx_time_chart.spark_driver_hive_external_catalog_files_discovered.id, signalfx_time_chart.spark_driver_hive_external_catalog_hive_client_calls.id, signalfx_time_chart.spark_driver_hive_external_catalog_parallel_listing_jobs.id, signalfx_time_chart.spark_driver_hive_external_catalog_partitions_fetched.id, signalfx_time_chart.spark_driver_code_generator_compilation_count.id, signalfx_time_chart.spark_driver_code_generator_compilation_average_time.id, signalfx_time_chart.spark_driver_code_generator_generated_class_count.id, signalfx_time_chart.spark_driver_code_generator_generated_class_average_size.id, signalfx_time_chart.spark_driver_code_generator_generated_method_count.id, signalfx_time_chart.spark_driver_code_generator_generated_method_average_size.id, signalfx_time_chart.spark_driver_code_generator_source_code_operations.id, signalfx_time_chart.spark_driver_code_generator_source_code_average_size.id, signalfx_time_chart.spark_driver_dag_scheduler_job_active.id, signalfx_time_chart.spark_driver_dag_scheduler_job_count.id, signalfx_time_chart.spark_driver_dag_scheduler_stage_failed.id, signalfx_time_chart.spark_driver_dag_scheduler_stage_count.id, signalfx_time_chart.spark_driver_live_listener_bus_posted.id, signalfx_time_chart.spark_driver_live_listener_bus_processing_time_average.id, signalfx_time_chart.spark_driver_live_listener_bus_dropped.id, signalfx_time_chart.spark_driver_live_listener_bus_queue_size.id, signalfx_time_chart.spark_driver_jvm_cpu_time.id, signalfx_time_chart.spark_driver_executor_memory_jvm.id, signalfx_time_chart.spark_driver_executor_memory_execution.id, signalfx_time_chart.spark_driver_executor_memory_storage.id, signalfx_time_chart.spark_driver_executor_memory_pool.id, signalfx_time_chart.spark_driver_executor_gc_operations.id, signalfx_time_chart.spark_driver_executor_gc_time.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "apachesparkdashboardgroup0" {
+  name        = "apachespark generated OTel dashboard group"
+  description = "apachespark generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "spark_stage_status" {
+  name = "A one-hot encoding representing the status of this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.status").publish(label="A one-hot encoding representing the status of this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_task_active" {
+  name = "Number of active tasks in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.task.active").publish(label="Number of active tasks in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_task_result" {
+  name = "Number of tasks with a specific result in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.task.result").publish(label="Number of tasks with a specific result in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_executor_run_time" {
+  name = "Amount of time spent by the executor in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.executor.run_time").publish(label="Amount of time spent by the executor in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_executor_cpu_time" {
+  name = "CPU time spent by the executor in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.executor.cpu_time").publish(label="CPU time spent by the executor in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_task_result_size" {
+  name = "The amount of data transmitted back to the driver by all the tasks in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.task.result_size").publish(label="The amount of data transmitted back to the driver by all the tasks in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_jvm_gc_time" {
+  name = "The amount of time the JVM spent on garbage collection in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.jvm_gc_time").publish(label="The amount of time the JVM spent on garbage collection in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_memory_spilled" {
+  name = "The amount of memory moved to disk due to size constraints (spilled) in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.memory.spilled").publish(label="The amount of memory moved to disk due to size constraints (spilled) in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_disk_spilled" {
+  name = "The amount of disk space used for storing portions of overly large data chunks that couldn't fit in memory in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.disk.spilled").publish(label="The amount of disk space used for storing portions of overly large data chunks that couldn't fit in memory in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_memory_peak" {
+  name = "Peak memory used by internal data structures created during shuffles, aggregations and joins in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.memory.peak").publish(label="Peak memory used by internal data structures created during shuffles, aggregations and joins in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_io_size" {
+  name = "Amount of data written and read at this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.io.size").publish(label="Amount of data written and read at this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_io_records" {
+  name = "Number of records written and read in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.io.records").publish(label="Number of records written and read in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_shuffle_blocks_fetched" {
+  name = "Number of blocks fetched in shuffle operations in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.shuffle.blocks_fetched").publish(label="Number of blocks fetched in shuffle operations in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_shuffle_fetch_wait_time" {
+  name = "Time spent in this stage waiting for remote shuffle blocks."
+
+  program_text = <<-EOF
+    data("spark.stage.shuffle.fetch_wait_time").publish(label="Time spent in this stage waiting for remote shuffle blocks.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_shuffle_io_disk" {
+  name = "Amount of data read to disk in shuffle operations (sometimes required for large blocks, as opposed to the default behavior of reading into memory)."
+
+  program_text = <<-EOF
+    data("spark.stage.shuffle.io.disk").publish(label="Amount of data read to disk in shuffle operations (sometimes required for large blocks, as opposed to the default behavior of reading into memory).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_shuffle_io_read_size" {
+  name = "Amount of data read in shuffle operations in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.shuffle.io.read.size").publish(label="Amount of data read in shuffle operations in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_shuffle_io_write_size" {
+  name = "Amount of data written in shuffle operations in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.shuffle.io.write.size").publish(label="Amount of data written in shuffle operations in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_shuffle_io_records" {
+  name = "Number of records written or read in shuffle operations in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.shuffle.io.records").publish(label="Number of records written or read in shuffle operations in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_stage_shuffle_write_time" {
+  name = "Time spent blocking on writes to disk or buffer cache in this stage."
+
+  program_text = <<-EOF
+    data("spark.stage.shuffle.write_time").publish(label="Time spent blocking on writes to disk or buffer cache in this stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_executor_memory_usage" {
+  name = "Storage memory used by this executor."
+
+  program_text = <<-EOF
+    data("spark.executor.memory.usage").publish(label="Storage memory used by this executor.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_executor_disk_usage" {
+  name = "Disk space used by this executor for RDD storage."
+
+  program_text = <<-EOF
+    data("spark.executor.disk.usage").publish(label="Disk space used by this executor for RDD storage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_executor_task_limit" {
+  name = "Maximum number of tasks that can run concurrently in this executor."
+
+  program_text = <<-EOF
+    data("spark.executor.task.limit").publish(label="Maximum number of tasks that can run concurrently in this executor.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_executor_task_active" {
+  name = "Number of tasks currently running in this executor."
+
+  program_text = <<-EOF
+    data("spark.executor.task.active").publish(label="Number of tasks currently running in this executor.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_executor_task_result" {
+  name = "Number of tasks with a specific result in this executor."
+
+  program_text = <<-EOF
+    data("spark.executor.task.result").publish(label="Number of tasks with a specific result in this executor.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_executor_time" {
+  name = "Elapsed time the JVM spent executing tasks in this executor."
+
+  program_text = <<-EOF
+    data("spark.executor.time").publish(label="Elapsed time the JVM spent executing tasks in this executor.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_executor_gc_time" {
+  name = "Elapsed time the JVM spent in garbage collection in this executor."
+
+  program_text = <<-EOF
+    data("spark.executor.gc_time").publish(label="Elapsed time the JVM spent in garbage collection in this executor.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_executor_input_size" {
+  name = "Amount of data input for this executor."
+
+  program_text = <<-EOF
+    data("spark.executor.input_size").publish(label="Amount of data input for this executor.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_executor_shuffle_io_size" {
+  name = "Amount of data written and read during shuffle operations for this executor."
+
+  program_text = <<-EOF
+    data("spark.executor.shuffle.io.size").publish(label="Amount of data written and read during shuffle operations for this executor.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_executor_storage_memory_usage" {
+  name = "The executor's storage memory usage."
+
+  program_text = <<-EOF
+    data("spark.executor.storage_memory.usage").publish(label="The executor's storage memory usage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_job_task_active" {
+  name = "Number of active tasks in this job."
+
+  program_text = <<-EOF
+    data("spark.job.task.active").publish(label="Number of active tasks in this job.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_job_task_result" {
+  name = "Number of tasks with a specific result in this job."
+
+  program_text = <<-EOF
+    data("spark.job.task.result").publish(label="Number of tasks with a specific result in this job.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_job_stage_active" {
+  name = "Number of active stages in this job."
+
+  program_text = <<-EOF
+    data("spark.job.stage.active").publish(label="Number of active stages in this job.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_job_stage_result" {
+  name = "Number of stages with a specific result in this job."
+
+  program_text = <<-EOF
+    data("spark.job.stage.result").publish(label="Number of stages with a specific result in this job.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_block_manager_disk_usage" {
+  name = "Disk space used by the BlockManager."
+
+  program_text = <<-EOF
+    data("spark.driver.block_manager.disk.usage").publish(label="Disk space used by the BlockManager.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_block_manager_memory_usage" {
+  name = "Memory usage for the driver's BlockManager."
+
+  program_text = <<-EOF
+    data("spark.driver.block_manager.memory.usage").publish(label="Memory usage for the driver's BlockManager.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_hive_external_catalog_file_cache_hits" {
+  name = "Number of file cache hits on the HiveExternalCatalog."
+
+  program_text = <<-EOF
+    data("spark.driver.hive_external_catalog.file_cache_hits").publish(label="Number of file cache hits on the HiveExternalCatalog.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_hive_external_catalog_files_discovered" {
+  name = "Number of files discovered while listing the partitions of a table in the Hive metastore"
+
+  program_text = <<-EOF
+    data("spark.driver.hive_external_catalog.files_discovered").publish(label="Number of files discovered while listing the partitions of a table in the Hive metastore")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_hive_external_catalog_hive_client_calls" {
+  name = "Number of calls to the underlying Hive Metastore client made by the Spark application."
+
+  program_text = <<-EOF
+    data("spark.driver.hive_external_catalog.hive_client_calls").publish(label="Number of calls to the underlying Hive Metastore client made by the Spark application.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_hive_external_catalog_parallel_listing_jobs" {
+  name = "Number of parallel listing jobs initiated by the HiveExternalCatalog when listing partitions of a table."
+
+  program_text = <<-EOF
+    data("spark.driver.hive_external_catalog.parallel_listing_jobs").publish(label="Number of parallel listing jobs initiated by the HiveExternalCatalog when listing partitions of a table.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_hive_external_catalog_partitions_fetched" {
+  name = "Table partitions fetched by the HiveExternalCatalog."
+
+  program_text = <<-EOF
+    data("spark.driver.hive_external_catalog.partitions_fetched").publish(label="Table partitions fetched by the HiveExternalCatalog.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_code_generator_compilation_count" {
+  name = "Number of source code compilation operations performed by the CodeGenerator."
+
+  program_text = <<-EOF
+    data("spark.driver.code_generator.compilation.count").publish(label="Number of source code compilation operations performed by the CodeGenerator.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_code_generator_compilation_average_time" {
+  name = "Average time spent during CodeGenerator source code compilation operations."
+
+  program_text = <<-EOF
+    data("spark.driver.code_generator.compilation.average_time").publish(label="Average time spent during CodeGenerator source code compilation operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_code_generator_generated_class_count" {
+  name = "Number of classes generated by the CodeGenerator."
+
+  program_text = <<-EOF
+    data("spark.driver.code_generator.generated_class.count").publish(label="Number of classes generated by the CodeGenerator.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_code_generator_generated_class_average_size" {
+  name = "Average class size of the classes generated by the CodeGenerator."
+
+  program_text = <<-EOF
+    data("spark.driver.code_generator.generated_class.average_size").publish(label="Average class size of the classes generated by the CodeGenerator.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_code_generator_generated_method_count" {
+  name = "Number of methods generated by the CodeGenerator."
+
+  program_text = <<-EOF
+    data("spark.driver.code_generator.generated_method.count").publish(label="Number of methods generated by the CodeGenerator.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_code_generator_generated_method_average_size" {
+  name = "Average method size of the classes generated by the CodeGenerator."
+
+  program_text = <<-EOF
+    data("spark.driver.code_generator.generated_method.average_size").publish(label="Average method size of the classes generated by the CodeGenerator.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_code_generator_source_code_operations" {
+  name = "Number of source code generation operations performed by the CodeGenerator."
+
+  program_text = <<-EOF
+    data("spark.driver.code_generator.source_code.operations").publish(label="Number of source code generation operations performed by the CodeGenerator.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_code_generator_source_code_average_size" {
+  name = "Average size of the source code generated by a CodeGenerator code generation operation."
+
+  program_text = <<-EOF
+    data("spark.driver.code_generator.source_code.average_size").publish(label="Average size of the source code generated by a CodeGenerator code generation operation.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_dag_scheduler_job_active" {
+  name = "Number of active jobs currently being processed by the DAGScheduler."
+
+  program_text = <<-EOF
+    data("spark.driver.dag_scheduler.job.active").publish(label="Number of active jobs currently being processed by the DAGScheduler.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_dag_scheduler_job_count" {
+  name = "Number of jobs that have been submitted to the DAGScheduler."
+
+  program_text = <<-EOF
+    data("spark.driver.dag_scheduler.job.count").publish(label="Number of jobs that have been submitted to the DAGScheduler.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_dag_scheduler_stage_failed" {
+  name = "Number of failed stages run by the DAGScheduler."
+
+  program_text = <<-EOF
+    data("spark.driver.dag_scheduler.stage.failed").publish(label="Number of failed stages run by the DAGScheduler.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_dag_scheduler_stage_count" {
+  name = "Number of stages the DAGScheduler is either running or needs to run."
+
+  program_text = <<-EOF
+    data("spark.driver.dag_scheduler.stage.count").publish(label="Number of stages the DAGScheduler is either running or needs to run.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_live_listener_bus_posted" {
+  name = "Number of events that have been posted on the LiveListenerBus."
+
+  program_text = <<-EOF
+    data("spark.driver.live_listener_bus.posted").publish(label="Number of events that have been posted on the LiveListenerBus.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_live_listener_bus_processing_time_average" {
+  name = "Average time taken for the LiveListenerBus to process an event posted to it."
+
+  program_text = <<-EOF
+    data("spark.driver.live_listener_bus.processing_time.average").publish(label="Average time taken for the LiveListenerBus to process an event posted to it.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_live_listener_bus_dropped" {
+  name = "Number of events that have been dropped by the LiveListenerBus."
+
+  program_text = <<-EOF
+    data("spark.driver.live_listener_bus.dropped").publish(label="Number of events that have been dropped by the LiveListenerBus.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_live_listener_bus_queue_size" {
+  name = "Number of events currently waiting to be processed by the LiveListenerBus."
+
+  program_text = <<-EOF
+    data("spark.driver.live_listener_bus.queue_size").publish(label="Number of events currently waiting to be processed by the LiveListenerBus.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_jvm_cpu_time" {
+  name = "Current CPU time taken by the Spark driver."
+
+  program_text = <<-EOF
+    data("spark.driver.jvm_cpu_time").publish(label="Current CPU time taken by the Spark driver.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_executor_memory_jvm" {
+  name = "Amount of memory used by the driver's JVM."
+
+  program_text = <<-EOF
+    data("spark.driver.executor.memory.jvm").publish(label="Amount of memory used by the driver's JVM.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_executor_memory_execution" {
+  name = "Amount of execution memory currently used by the driver."
+
+  program_text = <<-EOF
+    data("spark.driver.executor.memory.execution").publish(label="Amount of execution memory currently used by the driver.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_executor_memory_storage" {
+  name = "Amount of storage memory currently used by the driver."
+
+  program_text = <<-EOF
+    data("spark.driver.executor.memory.storage").publish(label="Amount of storage memory currently used by the driver.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_executor_memory_pool" {
+  name = "Amount of pool memory currently used by the driver."
+
+  program_text = <<-EOF
+    data("spark.driver.executor.memory.pool").publish(label="Amount of pool memory currently used by the driver.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_executor_gc_operations" {
+  name = "Number of garbage collection operations performed by the driver."
+
+  program_text = <<-EOF
+    data("spark.driver.executor.gc.operations").publish(label="Number of garbage collection operations performed by the driver.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "spark_driver_executor_gc_time" {
+  name = "Total elapsed time during garbage collection operations performed by the driver."
+
+  program_text = <<-EOF
+    data("spark.driver.executor.gc.time").publish(label="Total elapsed time during garbage collection operations performed by the driver.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/bigipreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/bigipreceiver_metadata.yaml.tf
@@ -1,0 +1,396 @@
+
+resource "signalfx_dashboard" "bigipdashboard" {
+  name            = "bigip"
+  dashboard_group = signalfx_dashboard_group.bigipdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.bigip_virtual_server_data_transmitted.id, signalfx_time_chart.bigip_virtual_server_connection_count.id, signalfx_time_chart.bigip_virtual_server_request_count.id, signalfx_time_chart.bigip_virtual_server_packet_count.id, signalfx_time_chart.bigip_virtual_server_availability.id, signalfx_time_chart.bigip_virtual_server_enabled.id, signalfx_time_chart.bigip_pool_data_transmitted.id, signalfx_time_chart.bigip_pool_connection_count.id, signalfx_time_chart.bigip_pool_request_count.id, signalfx_time_chart.bigip_pool_packet_count.id, signalfx_time_chart.bigip_pool_member_count.id, signalfx_time_chart.bigip_pool_availability.id, signalfx_time_chart.bigip_pool_enabled.id, signalfx_time_chart.bigip_pool_member_data_transmitted.id, signalfx_time_chart.bigip_pool_member_connection_count.id, signalfx_time_chart.bigip_pool_member_request_count.id, signalfx_time_chart.bigip_pool_member_packet_count.id, signalfx_time_chart.bigip_pool_member_session_count.id, signalfx_time_chart.bigip_pool_member_availability.id, signalfx_time_chart.bigip_pool_member_enabled.id, signalfx_time_chart.bigip_node_data_transmitted.id, signalfx_time_chart.bigip_node_connection_count.id, signalfx_time_chart.bigip_node_request_count.id, signalfx_time_chart.bigip_node_packet_count.id, signalfx_time_chart.bigip_node_session_count.id, signalfx_time_chart.bigip_node_availability.id, signalfx_time_chart.bigip_node_enabled.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "bigipdashboardgroup0" {
+  name        = "bigip generated OTel dashboard group"
+  description = "bigip generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "bigip_virtual_server_data_transmitted" {
+  name = "Amount of data transmitted to and from the virtual server."
+
+  program_text = <<-EOF
+    data("bigip.virtual_server.data.transmitted").publish(label="Amount of data transmitted to and from the virtual server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_virtual_server_connection_count" {
+  name = "Current number of connections to the virtual server."
+
+  program_text = <<-EOF
+    data("bigip.virtual_server.connection.count").publish(label="Current number of connections to the virtual server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_virtual_server_request_count" {
+  name = "Number of requests to the virtual server."
+
+  program_text = <<-EOF
+    data("bigip.virtual_server.request.count").publish(label="Number of requests to the virtual server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_virtual_server_packet_count" {
+  name = "Number of packets transmitted to and from the virtual server."
+
+  program_text = <<-EOF
+    data("bigip.virtual_server.packet.count").publish(label="Number of packets transmitted to and from the virtual server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_virtual_server_availability" {
+  name = "Availability of the virtual server."
+
+  program_text = <<-EOF
+    data("bigip.virtual_server.availability").publish(label="Availability of the virtual server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_virtual_server_enabled" {
+  name = "Enabled state of of the virtual server."
+
+  program_text = <<-EOF
+    data("bigip.virtual_server.enabled").publish(label="Enabled state of of the virtual server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_data_transmitted" {
+  name = "Amount of data transmitted to and from the pool."
+
+  program_text = <<-EOF
+    data("bigip.pool.data.transmitted").publish(label="Amount of data transmitted to and from the pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_connection_count" {
+  name = "Current number of connections to the pool."
+
+  program_text = <<-EOF
+    data("bigip.pool.connection.count").publish(label="Current number of connections to the pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_request_count" {
+  name = "Number of requests to the pool."
+
+  program_text = <<-EOF
+    data("bigip.pool.request.count").publish(label="Number of requests to the pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_packet_count" {
+  name = "Number of packets transmitted to and from the pool."
+
+  program_text = <<-EOF
+    data("bigip.pool.packet.count").publish(label="Number of packets transmitted to and from the pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_member_count" {
+  name = "Total number of pool members."
+
+  program_text = <<-EOF
+    data("bigip.pool.member.count").publish(label="Total number of pool members.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_availability" {
+  name = "Availability of the pool."
+
+  program_text = <<-EOF
+    data("bigip.pool.availability").publish(label="Availability of the pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_enabled" {
+  name = "Enabled state of of the pool."
+
+  program_text = <<-EOF
+    data("bigip.pool.enabled").publish(label="Enabled state of of the pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_member_data_transmitted" {
+  name = "Amount of data transmitted to and from the pool member."
+
+  program_text = <<-EOF
+    data("bigip.pool_member.data.transmitted").publish(label="Amount of data transmitted to and from the pool member.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_member_connection_count" {
+  name = "Current number of connections to the pool member."
+
+  program_text = <<-EOF
+    data("bigip.pool_member.connection.count").publish(label="Current number of connections to the pool member.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_member_request_count" {
+  name = "Number of requests to the pool member."
+
+  program_text = <<-EOF
+    data("bigip.pool_member.request.count").publish(label="Number of requests to the pool member.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_member_packet_count" {
+  name = "Number of packets transmitted to and from the pool member."
+
+  program_text = <<-EOF
+    data("bigip.pool_member.packet.count").publish(label="Number of packets transmitted to and from the pool member.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_member_session_count" {
+  name = "Current number of sessions for the pool member."
+
+  program_text = <<-EOF
+    data("bigip.pool_member.session.count").publish(label="Current number of sessions for the pool member.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_member_availability" {
+  name = "Availability of the pool member."
+
+  program_text = <<-EOF
+    data("bigip.pool_member.availability").publish(label="Availability of the pool member.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_pool_member_enabled" {
+  name = "Enabled state of of the pool member."
+
+  program_text = <<-EOF
+    data("bigip.pool_member.enabled").publish(label="Enabled state of of the pool member.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_node_data_transmitted" {
+  name = "Amount of data transmitted to and from the node."
+
+  program_text = <<-EOF
+    data("bigip.node.data.transmitted").publish(label="Amount of data transmitted to and from the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_node_connection_count" {
+  name = "Current number of connections to the node."
+
+  program_text = <<-EOF
+    data("bigip.node.connection.count").publish(label="Current number of connections to the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_node_request_count" {
+  name = "Number of requests to the node."
+
+  program_text = <<-EOF
+    data("bigip.node.request.count").publish(label="Number of requests to the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_node_packet_count" {
+  name = "Number of packets transmitted to and from the node."
+
+  program_text = <<-EOF
+    data("bigip.node.packet.count").publish(label="Number of packets transmitted to and from the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_node_session_count" {
+  name = "Current number of sessions for the node."
+
+  program_text = <<-EOF
+    data("bigip.node.session.count").publish(label="Current number of sessions for the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_node_availability" {
+  name = "Availability of the node."
+
+  program_text = <<-EOF
+    data("bigip.node.availability").publish(label="Availability of the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "bigip_node_enabled" {
+  name = "Enabled state of of the node."
+
+  program_text = <<-EOF
+    data("bigip.node.enabled").publish(label="Enabled state of of the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/chronyreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/chronyreceiver_metadata.yaml.tf
@@ -1,0 +1,116 @@
+
+resource "signalfx_dashboard" "chronydashboard" {
+  name            = "chrony"
+  dashboard_group = signalfx_dashboard_group.chronydashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.ntp_frequency_offset.id, signalfx_time_chart.ntp_skew.id, signalfx_time_chart.ntp_stratum.id, signalfx_time_chart.ntp_time_correction.id, signalfx_time_chart.ntp_time_last_offset.id, signalfx_time_chart.ntp_time_rms_offset.id, signalfx_time_chart.ntp_time_root_delay.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "chronydashboardgroup0" {
+  name        = "chrony generated OTel dashboard group"
+  description = "chrony generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "ntp_frequency_offset" {
+  name = "The frequency is the rate by which the system s clock would be wrong if chronyd was not correcting it."
+
+  program_text = <<-EOF
+    data("ntp.frequency.offset").publish(label="The frequency is the rate by which the system s clock would be wrong if chronyd was not correcting it.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "ntp_skew" {
+  name = "This is the estimated error bound on the frequency."
+
+  program_text = <<-EOF
+    data("ntp.skew").publish(label="This is the estimated error bound on the frequency.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "ntp_stratum" {
+  name = "The number of hops away from the reference system keeping the reference time"
+
+  program_text = <<-EOF
+    data("ntp.stratum").publish(label="The number of hops away from the reference system keeping the reference time")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "ntp_time_correction" {
+  name = "The number of seconds difference between the system's clock and the reference clock"
+
+  program_text = <<-EOF
+    data("ntp.time.correction").publish(label="The number of seconds difference between the system's clock and the reference clock")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "ntp_time_last_offset" {
+  name = "The estimated local offset on the last clock update"
+
+  program_text = <<-EOF
+    data("ntp.time.last_offset").publish(label="The estimated local offset on the last clock update")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "ntp_time_rms_offset" {
+  name = "the long term average of the offset value"
+
+  program_text = <<-EOF
+    data("ntp.time.rms_offset").publish(label="the long term average of the offset value")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "ntp_time_root_delay" {
+  name = "This is the total of the network path delays to the stratum-1 system from which the system is ultimately synchronised."
+
+  program_text = <<-EOF
+    data("ntp.time.root_delay").publish(label="This is the total of the network path delays to the stratum-1 system from which the system is ultimately synchronised.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/couchdbreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/couchdbreceiver_metadata.yaml.tf
@@ -1,0 +1,130 @@
+
+resource "signalfx_dashboard" "couchdbdashboard" {
+  name            = "couchdb"
+  dashboard_group = signalfx_dashboard_group.couchdbdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.couchdb_average_request_time.id, signalfx_time_chart.couchdb_httpd_bulk_requests.id, signalfx_time_chart.couchdb_httpd_requests.id, signalfx_time_chart.couchdb_httpd_responses.id, signalfx_time_chart.couchdb_httpd_views.id, signalfx_time_chart.couchdb_database_open.id, signalfx_time_chart.couchdb_file_descriptor_open.id, signalfx_time_chart.couchdb_database_operations.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "couchdbdashboardgroup0" {
+  name        = "couchdb generated OTel dashboard group"
+  description = "couchdb generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "couchdb_average_request_time" {
+  name = "The average duration of a served request."
+
+  program_text = <<-EOF
+    data("couchdb.average_request_time").publish(label="The average duration of a served request.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "couchdb_httpd_bulk_requests" {
+  name = "The number of bulk requests."
+
+  program_text = <<-EOF
+    data("couchdb.httpd.bulk_requests").publish(label="The number of bulk requests.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "couchdb_httpd_requests" {
+  name = "The number of HTTP requests by method."
+
+  program_text = <<-EOF
+    data("couchdb.httpd.requests").publish(label="The number of HTTP requests by method.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "couchdb_httpd_responses" {
+  name = "The number of each HTTP status code."
+
+  program_text = <<-EOF
+    data("couchdb.httpd.responses").publish(label="The number of each HTTP status code.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "couchdb_httpd_views" {
+  name = "The number of views read."
+
+  program_text = <<-EOF
+    data("couchdb.httpd.views").publish(label="The number of views read.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "couchdb_database_open" {
+  name = "The number of open databases."
+
+  program_text = <<-EOF
+    data("couchdb.database.open").publish(label="The number of open databases.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "couchdb_file_descriptor_open" {
+  name = "The number of open file descriptors."
+
+  program_text = <<-EOF
+    data("couchdb.file_descriptor.open").publish(label="The number of open file descriptors.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "couchdb_database_operations" {
+  name = "The number of database operations."
+
+  program_text = <<-EOF
+    data("couchdb.database.operations").publish(label="The number of database operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/dockerstatsreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/dockerstatsreceiver_metadata.yaml.tf
@@ -1,0 +1,984 @@
+
+resource "signalfx_dashboard" "docker_statsdashboard" {
+  name            = "docker_stats"
+  dashboard_group = signalfx_dashboard_group.docker_statsdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.container_cpu_usage_system.id, signalfx_time_chart.container_cpu_usage_total.id, signalfx_time_chart.container_cpu_usage_kernelmode.id, signalfx_time_chart.container_cpu_usage_usermode.id, signalfx_time_chart.container_cpu_usage_percpu.id, signalfx_time_chart.container_cpu_throttling_data_periods.id, signalfx_time_chart.container_cpu_throttling_data_throttled_periods.id, signalfx_time_chart.container_cpu_throttling_data_throttled_time.id, signalfx_time_chart.container_cpu_utilization.id, signalfx_time_chart.container_cpu_limit.id, signalfx_time_chart.container_cpu_shares.id, signalfx_time_chart.container_memory_usage_limit.id, signalfx_time_chart.container_memory_usage_total.id, signalfx_time_chart.container_memory_usage_max.id, signalfx_time_chart.container_memory_percent.id, signalfx_time_chart.container_memory_cache.id, signalfx_time_chart.container_memory_rss.id, signalfx_time_chart.container_memory_rss_huge.id, signalfx_time_chart.container_memory_dirty.id, signalfx_time_chart.container_memory_writeback.id, signalfx_time_chart.container_memory_mapped_file.id, signalfx_time_chart.container_memory_pgpgin.id, signalfx_time_chart.container_memory_pgpgout.id, signalfx_time_chart.container_memory_pgfault.id, signalfx_time_chart.container_memory_pgmajfault.id, signalfx_time_chart.container_memory_inactive_anon.id, signalfx_time_chart.container_memory_active_anon.id, signalfx_time_chart.container_memory_inactive_file.id, signalfx_time_chart.container_memory_active_file.id, signalfx_time_chart.container_memory_unevictable.id, signalfx_time_chart.container_memory_hierarchical_memory_limit.id, signalfx_time_chart.container_memory_hierarchical_memsw_limit.id, signalfx_time_chart.container_memory_total_cache.id, signalfx_time_chart.container_memory_total_rss.id, signalfx_time_chart.container_memory_total_rss_huge.id, signalfx_time_chart.container_memory_total_dirty.id, signalfx_time_chart.container_memory_total_writeback.id, signalfx_time_chart.container_memory_total_mapped_file.id, signalfx_time_chart.container_memory_total_pgpgin.id, signalfx_time_chart.container_memory_total_pgpgout.id, signalfx_time_chart.container_memory_total_pgfault.id, signalfx_time_chart.container_memory_total_pgmajfault.id, signalfx_time_chart.container_memory_total_inactive_anon.id, signalfx_time_chart.container_memory_total_active_anon.id, signalfx_time_chart.container_memory_total_inactive_file.id, signalfx_time_chart.container_memory_total_active_file.id, signalfx_time_chart.container_memory_total_unevictable.id, signalfx_time_chart.container_memory_anon.id, signalfx_time_chart.container_memory_file.id, signalfx_time_chart.container_blockio_io_merged_recursive.id, signalfx_time_chart.container_blockio_io_queued_recursive.id, signalfx_time_chart.container_blockio_io_service_bytes_recursive.id, signalfx_time_chart.container_blockio_io_service_time_recursive.id, signalfx_time_chart.container_blockio_io_serviced_recursive.id, signalfx_time_chart.container_blockio_io_time_recursive.id, signalfx_time_chart.container_blockio_io_wait_time_recursive.id, signalfx_time_chart.container_blockio_sectors_recursive.id, signalfx_time_chart.container_network_io_usage_rx_bytes.id, signalfx_time_chart.container_network_io_usage_tx_bytes.id, signalfx_time_chart.container_network_io_usage_rx_dropped.id, signalfx_time_chart.container_network_io_usage_tx_dropped.id, signalfx_time_chart.container_network_io_usage_rx_errors.id, signalfx_time_chart.container_network_io_usage_tx_errors.id, signalfx_time_chart.container_network_io_usage_rx_packets.id, signalfx_time_chart.container_network_io_usage_tx_packets.id, signalfx_time_chart.container_pids_count.id, signalfx_time_chart.container_pids_limit.id, signalfx_time_chart.container_uptime.id, signalfx_time_chart.container_restarts.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "docker_statsdashboardgroup0" {
+  name        = "docker_stats generated OTel dashboard group"
+  description = "docker_stats generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "container_cpu_usage_system" {
+  name = "System CPU usage, as reported by docker."
+
+  program_text = <<-EOF
+    data("container.cpu.usage.system").publish(label="System CPU usage, as reported by docker.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_usage_total" {
+  name = "Total CPU time consumed."
+
+  program_text = <<-EOF
+    data("container.cpu.usage.total").publish(label="Total CPU time consumed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_usage_kernelmode" {
+  name = "Time spent by tasks of the cgroup in kernel mode (Linux).  Time spent by all container processes in kernel mode (Windows)."
+
+  program_text = <<-EOF
+    data("container.cpu.usage.kernelmode").publish(label="Time spent by tasks of the cgroup in kernel mode (Linux).  Time spent by all container processes in kernel mode (Windows).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_usage_usermode" {
+  name = "Time spent by tasks of the cgroup in user mode (Linux).  Time spent by all container processes in user mode (Windows)."
+
+  program_text = <<-EOF
+    data("container.cpu.usage.usermode").publish(label="Time spent by tasks of the cgroup in user mode (Linux).  Time spent by all container processes in user mode (Windows).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_usage_percpu" {
+  name = "Per-core CPU usage by the container (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.cpu.usage.percpu").publish(label="Per-core CPU usage by the container (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_throttling_data_periods" {
+  name = "Number of periods with throttling active."
+
+  program_text = <<-EOF
+    data("container.cpu.throttling_data.periods").publish(label="Number of periods with throttling active.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_throttling_data_throttled_periods" {
+  name = "Number of periods when the container hits its throttling limit."
+
+  program_text = <<-EOF
+    data("container.cpu.throttling_data.throttled_periods").publish(label="Number of periods when the container hits its throttling limit.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_throttling_data_throttled_time" {
+  name = "Aggregate time the container was throttled."
+
+  program_text = <<-EOF
+    data("container.cpu.throttling_data.throttled_time").publish(label="Aggregate time the container was throttled.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_utilization" {
+  name = "Percent of CPU used by the container."
+
+  program_text = <<-EOF
+    data("container.cpu.utilization").publish(label="Percent of CPU used by the container.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_limit" {
+  name = "CPU limit set for the container."
+
+  program_text = <<-EOF
+    data("container.cpu.limit").publish(label="CPU limit set for the container.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_shares" {
+  name = "CPU shares set for the container."
+
+  program_text = <<-EOF
+    data("container.cpu.shares").publish(label="CPU shares set for the container.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_usage_limit" {
+  name = "Memory limit of the container."
+
+  program_text = <<-EOF
+    data("container.memory.usage.limit").publish(label="Memory limit of the container.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_usage_total" {
+  name = "Memory usage of the container. This excludes the cache."
+
+  program_text = <<-EOF
+    data("container.memory.usage.total").publish(label="Memory usage of the container. This excludes the cache.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_usage_max" {
+  name = "Maximum memory usage."
+
+  program_text = <<-EOF
+    data("container.memory.usage.max").publish(label="Maximum memory usage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_percent" {
+  name = "Percentage of memory used."
+
+  program_text = <<-EOF
+    data("container.memory.percent").publish(label="Percentage of memory used.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_cache" {
+  name = "The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.cache").publish(label="The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_rss" {
+  name = "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.rss").publish(label="The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_rss_huge" {
+  name = "Number of bytes of anonymous transparent hugepages in this cgroup (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.rss_huge").publish(label="Number of bytes of anonymous transparent hugepages in this cgroup (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_dirty" {
+  name = "Bytes that are waiting to get written back to the disk, from this cgroup (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.dirty").publish(label="Bytes that are waiting to get written back to the disk, from this cgroup (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_writeback" {
+  name = "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.writeback").publish(label="Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_mapped_file" {
+  name = "Indicates the amount of memory mapped by the processes in the control group (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.mapped_file").publish(label="Indicates the amount of memory mapped by the processes in the control group (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_pgpgin" {
+  name = "Number of pages read from disk by the cgroup (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.pgpgin").publish(label="Number of pages read from disk by the cgroup (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_pgpgout" {
+  name = "Number of pages written to disk by the cgroup (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.pgpgout").publish(label="Number of pages written to disk by the cgroup (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_pgfault" {
+  name = "Indicate the number of times that a process of the cgroup triggered a page fault."
+
+  program_text = <<-EOF
+    data("container.memory.pgfault").publish(label="Indicate the number of times that a process of the cgroup triggered a page fault.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_pgmajfault" {
+  name = "Indicate the number of times that a process of the cgroup triggered a major fault."
+
+  program_text = <<-EOF
+    data("container.memory.pgmajfault").publish(label="Indicate the number of times that a process of the cgroup triggered a major fault.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_inactive_anon" {
+  name = "The amount of anonymous memory that has been identified as inactive by the kernel."
+
+  program_text = <<-EOF
+    data("container.memory.inactive_anon").publish(label="The amount of anonymous memory that has been identified as inactive by the kernel.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_active_anon" {
+  name = "The amount of anonymous memory that has been identified as active by the kernel."
+
+  program_text = <<-EOF
+    data("container.memory.active_anon").publish(label="The amount of anonymous memory that has been identified as active by the kernel.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_inactive_file" {
+  name = "Cache memory that has been identified as inactive by the kernel."
+
+  program_text = <<-EOF
+    data("container.memory.inactive_file").publish(label="Cache memory that has been identified as inactive by the kernel.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_active_file" {
+  name = "Cache memory that has been identified as active by the kernel."
+
+  program_text = <<-EOF
+    data("container.memory.active_file").publish(label="Cache memory that has been identified as active by the kernel.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_unevictable" {
+  name = "The amount of memory that cannot be reclaimed."
+
+  program_text = <<-EOF
+    data("container.memory.unevictable").publish(label="The amount of memory that cannot be reclaimed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_hierarchical_memory_limit" {
+  name = "The maximum amount of physical memory that can be used by the processes of this control group (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.hierarchical_memory_limit").publish(label="The maximum amount of physical memory that can be used by the processes of this control group (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_hierarchical_memsw_limit" {
+  name = "The maximum amount of RAM + swap that can be used by the processes of this control group (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.hierarchical_memsw_limit").publish(label="The maximum amount of RAM + swap that can be used by the processes of this control group (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_cache" {
+  name = "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_cache").publish(label="Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_rss" {
+  name = "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_rss").publish(label="The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_rss_huge" {
+  name = "Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_rss_huge").publish(label="Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_dirty" {
+  name = "Bytes that are waiting to get written back to the disk, from this cgroup and descendants (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_dirty").publish(label="Bytes that are waiting to get written back to the disk, from this cgroup and descendants (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_writeback" {
+  name = "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_writeback").publish(label="Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_mapped_file" {
+  name = "Indicates the amount of memory mapped by the processes in the control group and descendant groups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_mapped_file").publish(label="Indicates the amount of memory mapped by the processes in the control group and descendant groups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_pgpgin" {
+  name = "Number of pages read from disk by the cgroup and descendant groups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_pgpgin").publish(label="Number of pages read from disk by the cgroup and descendant groups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_pgpgout" {
+  name = "Number of pages written to disk by the cgroup and descendant groups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_pgpgout").publish(label="Number of pages written to disk by the cgroup and descendant groups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_pgfault" {
+  name = "Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a page fault (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_pgfault").publish(label="Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a page fault (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_pgmajfault" {
+  name = "Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a major fault (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_pgmajfault").publish(label="Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a major fault (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_inactive_anon" {
+  name = "The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_inactive_anon").publish(label="The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_active_anon" {
+  name = "The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_active_anon").publish(label="The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_inactive_file" {
+  name = "Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_inactive_file").publish(label="Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_active_file" {
+  name = "Cache memory that has been identified as active by the kernel. Includes descendant cgroups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_active_file").publish(label="Cache memory that has been identified as active by the kernel. Includes descendant cgroups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_total_unevictable" {
+  name = "The amount of memory that cannot be reclaimed. Includes descendant cgroups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.memory.total_unevictable").publish(label="The amount of memory that cannot be reclaimed. Includes descendant cgroups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_anon" {
+  name = "Amount of memory used in anonymous mappings such as brk(), sbrk(), and mmap(MAP_ANONYMOUS) (Only available with cgroups v2)."
+
+  program_text = <<-EOF
+    data("container.memory.anon").publish(label="Amount of memory used in anonymous mappings such as brk(), sbrk(), and mmap(MAP_ANONYMOUS) (Only available with cgroups v2).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_file" {
+  name = "Amount of memory used to cache filesystem data, including tmpfs and shared memory (Only available with cgroups v2)."
+
+  program_text = <<-EOF
+    data("container.memory.file").publish(label="Amount of memory used to cache filesystem data, including tmpfs and shared memory (Only available with cgroups v2).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_blockio_io_merged_recursive" {
+  name = "Number of bios/requests merged into requests belonging to this cgroup and its descendant cgroups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.blockio.io_merged_recursive").publish(label="Number of bios/requests merged into requests belonging to this cgroup and its descendant cgroups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_blockio_io_queued_recursive" {
+  name = "Number of requests queued up for this cgroup and its descendant cgroups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.blockio.io_queued_recursive").publish(label="Number of requests queued up for this cgroup and its descendant cgroups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_blockio_io_service_bytes_recursive" {
+  name = "Number of bytes transferred to/from the disk by the group and descendant groups."
+
+  program_text = <<-EOF
+    data("container.blockio.io_service_bytes_recursive").publish(label="Number of bytes transferred to/from the disk by the group and descendant groups.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_blockio_io_service_time_recursive" {
+  name = "Total amount of time in nanoseconds between request dispatch and request completion for the IOs done by this cgroup and descendant cgroups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.blockio.io_service_time_recursive").publish(label="Total amount of time in nanoseconds between request dispatch and request completion for the IOs done by this cgroup and descendant cgroups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_blockio_io_serviced_recursive" {
+  name = "Number of IOs (bio) issued to the disk by the group and descendant groups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.blockio.io_serviced_recursive").publish(label="Number of IOs (bio) issued to the disk by the group and descendant groups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_blockio_io_time_recursive" {
+  name = "Disk time allocated to cgroup (and descendant cgroups) per device in milliseconds (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.blockio.io_time_recursive").publish(label="Disk time allocated to cgroup (and descendant cgroups) per device in milliseconds (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_blockio_io_wait_time_recursive" {
+  name = "Total amount of time the IOs for this cgroup (and descendant cgroups) spent waiting in the scheduler queues for service (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.blockio.io_wait_time_recursive").publish(label="Total amount of time the IOs for this cgroup (and descendant cgroups) spent waiting in the scheduler queues for service (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_blockio_sectors_recursive" {
+  name = "Number of sectors transferred to/from disk by the group and descendant groups (Only available with cgroups v1)."
+
+  program_text = <<-EOF
+    data("container.blockio.sectors_recursive").publish(label="Number of sectors transferred to/from disk by the group and descendant groups (Only available with cgroups v1).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_network_io_usage_rx_bytes" {
+  name = "Bytes received by the container."
+
+  program_text = <<-EOF
+    data("container.network.io.usage.rx_bytes").publish(label="Bytes received by the container.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_network_io_usage_tx_bytes" {
+  name = "Bytes sent."
+
+  program_text = <<-EOF
+    data("container.network.io.usage.tx_bytes").publish(label="Bytes sent.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_network_io_usage_rx_dropped" {
+  name = "Incoming packets dropped."
+
+  program_text = <<-EOF
+    data("container.network.io.usage.rx_dropped").publish(label="Incoming packets dropped.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_network_io_usage_tx_dropped" {
+  name = "Outgoing packets dropped."
+
+  program_text = <<-EOF
+    data("container.network.io.usage.tx_dropped").publish(label="Outgoing packets dropped.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_network_io_usage_rx_errors" {
+  name = "Received errors."
+
+  program_text = <<-EOF
+    data("container.network.io.usage.rx_errors").publish(label="Received errors.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_network_io_usage_tx_errors" {
+  name = "Sent errors."
+
+  program_text = <<-EOF
+    data("container.network.io.usage.tx_errors").publish(label="Sent errors.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_network_io_usage_rx_packets" {
+  name = "Packets received."
+
+  program_text = <<-EOF
+    data("container.network.io.usage.rx_packets").publish(label="Packets received.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_network_io_usage_tx_packets" {
+  name = "Packets sent."
+
+  program_text = <<-EOF
+    data("container.network.io.usage.tx_packets").publish(label="Packets sent.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_pids_count" {
+  name = "Number of pids in the container's cgroup."
+
+  program_text = <<-EOF
+    data("container.pids.count").publish(label="Number of pids in the container's cgroup.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_pids_limit" {
+  name = "Maximum number of pids in the container's cgroup."
+
+  program_text = <<-EOF
+    data("container.pids.limit").publish(label="Maximum number of pids in the container's cgroup.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_uptime" {
+  name = "Time elapsed since container start time."
+
+  program_text = <<-EOF
+    data("container.uptime").publish(label="Time elapsed since container start time.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_restarts" {
+  name = "Number of restarts for the container."
+
+  program_text = <<-EOF
+    data("container.restarts").publish(label="Number of restarts for the container.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/elasticsearchreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/elasticsearchreceiver_metadata.yaml.tf
@@ -1,0 +1,1292 @@
+
+resource "signalfx_dashboard" "elasticsearchdashboard" {
+  name            = "elasticsearch"
+  dashboard_group = signalfx_dashboard_group.elasticsearchdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.elasticsearch_breaker_memory_estimated.id, signalfx_time_chart.elasticsearch_breaker_memory_limit.id, signalfx_time_chart.elasticsearch_breaker_tripped.id, signalfx_time_chart.elasticsearch_node_cache_memory_usage.id, signalfx_time_chart.elasticsearch_node_cache_evictions.id, signalfx_time_chart.elasticsearch_node_cache_count.id, signalfx_time_chart.elasticsearch_node_cache_size.id, signalfx_time_chart.elasticsearch_node_fs_disk_available.id, signalfx_time_chart.elasticsearch_node_fs_disk_free.id, signalfx_time_chart.elasticsearch_node_fs_disk_total.id, signalfx_time_chart.elasticsearch_node_disk_io_read.id, signalfx_time_chart.elasticsearch_node_disk_io_write.id, signalfx_time_chart.elasticsearch_node_cluster_io.id, signalfx_time_chart.elasticsearch_node_cluster_connections.id, signalfx_time_chart.elasticsearch_node_http_connections.id, signalfx_time_chart.elasticsearch_node_operations_current.id, signalfx_time_chart.elasticsearch_node_operations_completed.id, signalfx_time_chart.elasticsearch_node_operations_time.id, signalfx_time_chart.elasticsearch_node_operations_get_completed.id, signalfx_time_chart.elasticsearch_node_operations_get_time.id, signalfx_time_chart.elasticsearch_node_shards_size.id, signalfx_time_chart.elasticsearch_node_shards_data_set_size.id, signalfx_time_chart.elasticsearch_node_shards_reserved_size.id, signalfx_time_chart.elasticsearch_node_translog_operations.id, signalfx_time_chart.elasticsearch_node_translog_size.id, signalfx_time_chart.elasticsearch_node_translog_uncommitted_size.id, signalfx_time_chart.elasticsearch_node_thread_pool_threads.id, signalfx_time_chart.elasticsearch_node_thread_pool_tasks_queued.id, signalfx_time_chart.elasticsearch_node_thread_pool_tasks_finished.id, signalfx_time_chart.elasticsearch_node_documents.id, signalfx_time_chart.elasticsearch_node_open_files.id, signalfx_time_chart.jvm_classes_loaded.id, signalfx_time_chart.jvm_gc_collections_count.id, signalfx_time_chart.jvm_gc_collections_elapsed.id, signalfx_time_chart.jvm_memory_heap_max.id, signalfx_time_chart.jvm_memory_heap_used.id, signalfx_time_chart.jvm_memory_heap_utilization.id, signalfx_time_chart.jvm_memory_heap_committed.id, signalfx_time_chart.jvm_memory_nonheap_used.id, signalfx_time_chart.jvm_memory_nonheap_committed.id, signalfx_time_chart.jvm_memory_pool_max.id, signalfx_time_chart.jvm_memory_pool_used.id, signalfx_time_chart.jvm_threads_count.id, signalfx_time_chart.elasticsearch_cluster_pending_tasks.id, signalfx_time_chart.elasticsearch_cluster_in_flight_fetch.id, signalfx_time_chart.elasticsearch_cluster_shards.id, signalfx_time_chart.elasticsearch_cluster_data_nodes.id, signalfx_time_chart.elasticsearch_cluster_nodes.id, signalfx_time_chart.elasticsearch_cluster_health.id, signalfx_time_chart.elasticsearch_os_cpu_usage.id, signalfx_time_chart.elasticsearch_os_cpu_load_avg_1m.id, signalfx_time_chart.elasticsearch_os_cpu_load_avg_5m.id, signalfx_time_chart.elasticsearch_os_cpu_load_avg_15m.id, signalfx_time_chart.elasticsearch_os_memory.id, signalfx_time_chart.elasticsearch_memory_indexing_pressure.id, signalfx_time_chart.elasticsearch_indexing_pressure_memory_total_primary_rejections.id, signalfx_time_chart.elasticsearch_indexing_pressure_memory_total_replica_rejections.id, signalfx_time_chart.elasticsearch_indexing_pressure_memory_limit.id, signalfx_time_chart.elasticsearch_cluster_state_queue.id, signalfx_time_chart.elasticsearch_cluster_published_states_full.id, signalfx_time_chart.elasticsearch_cluster_published_states_differences.id, signalfx_time_chart.elasticsearch_cluster_state_update_count.id, signalfx_time_chart.elasticsearch_cluster_state_update_time.id, signalfx_time_chart.elasticsearch_cluster_indices_cache_evictions.id, signalfx_time_chart.elasticsearch_node_ingest_documents.id, signalfx_time_chart.elasticsearch_node_ingest_documents_current.id, signalfx_time_chart.elasticsearch_node_ingest_operations_failed.id, signalfx_time_chart.elasticsearch_node_pipeline_ingest_documents_preprocessed.id, signalfx_time_chart.elasticsearch_node_pipeline_ingest_operations_failed.id, signalfx_time_chart.elasticsearch_node_pipeline_ingest_documents_current.id, signalfx_time_chart.elasticsearch_node_script_compilations.id, signalfx_time_chart.elasticsearch_node_script_cache_evictions.id, signalfx_time_chart.elasticsearch_node_script_compilation_limit_triggered.id, signalfx_time_chart.elasticsearch_node_segments_memory.id, signalfx_time_chart.elasticsearch_index_operations_completed.id, signalfx_time_chart.elasticsearch_index_operations_time.id, signalfx_time_chart.elasticsearch_index_shards_size.id, signalfx_time_chart.elasticsearch_index_operations_merge_size.id, signalfx_time_chart.elasticsearch_index_operations_merge_docs_count.id, signalfx_time_chart.elasticsearch_index_segments_count.id, signalfx_time_chart.elasticsearch_index_segments_size.id, signalfx_time_chart.elasticsearch_index_segments_memory.id, signalfx_time_chart.elasticsearch_index_translog_operations.id, signalfx_time_chart.elasticsearch_index_translog_size.id, signalfx_time_chart.elasticsearch_index_cache_memory_usage.id, signalfx_time_chart.elasticsearch_index_cache_size.id, signalfx_time_chart.elasticsearch_index_cache_evictions.id, signalfx_time_chart.elasticsearch_index_documents.id, signalfx_time_chart.elasticsearch_process_cpu_usage.id, signalfx_time_chart.elasticsearch_process_cpu_time.id, signalfx_time_chart.elasticsearch_process_memory_virtual.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "elasticsearchdashboardgroup0" {
+  name        = "elasticsearch generated OTel dashboard group"
+  description = "elasticsearch generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "elasticsearch_breaker_memory_estimated" {
+  name = "Estimated memory used for the operation."
+
+  program_text = <<-EOF
+    data("elasticsearch.breaker.memory.estimated").publish(label="Estimated memory used for the operation.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_breaker_memory_limit" {
+  name = "Memory limit for the circuit breaker."
+
+  program_text = <<-EOF
+    data("elasticsearch.breaker.memory.limit").publish(label="Memory limit for the circuit breaker.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_breaker_tripped" {
+  name = "Total number of times the circuit breaker has been triggered and prevented an out of memory error."
+
+  program_text = <<-EOF
+    data("elasticsearch.breaker.tripped").publish(label="Total number of times the circuit breaker has been triggered and prevented an out of memory error.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_cache_memory_usage" {
+  name = "The size in bytes of the cache on a node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.cache.memory.usage").publish(label="The size in bytes of the cache on a node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_cache_evictions" {
+  name = "The number of evictions from the cache on a node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.cache.evictions").publish(label="The number of evictions from the cache on a node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_cache_count" {
+  name = "Total count of query cache misses across all shards assigned to selected nodes."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.cache.count").publish(label="Total count of query cache misses across all shards assigned to selected nodes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_cache_size" {
+  name = "Total amount of memory used for the query cache across all shards assigned to the node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.cache.size").publish(label="Total amount of memory used for the query cache across all shards assigned to the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_fs_disk_available" {
+  name = "The amount of disk space available to the JVM across all file stores for this node. Depending on OS or process level restrictions, this might appear less than free. This is the actual amount of free disk space the Elasticsearch node can utilise."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.fs.disk.available").publish(label="The amount of disk space available to the JVM across all file stores for this node. Depending on OS or process level restrictions, this might appear less than free. This is the actual amount of free disk space the Elasticsearch node can utilise.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_fs_disk_free" {
+  name = "The amount of unallocated disk space across all file stores for this node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.fs.disk.free").publish(label="The amount of unallocated disk space across all file stores for this node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_fs_disk_total" {
+  name = "The amount of disk space across all file stores for this node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.fs.disk.total").publish(label="The amount of disk space across all file stores for this node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_disk_io_read" {
+  name = "The total number of kilobytes read across all file stores for this node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.disk.io.read").publish(label="The total number of kilobytes read across all file stores for this node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_disk_io_write" {
+  name = "The total number of kilobytes written across all file stores for this node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.disk.io.write").publish(label="The total number of kilobytes written across all file stores for this node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_cluster_io" {
+  name = "The number of bytes sent and received on the network for internal cluster communication."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.cluster.io").publish(label="The number of bytes sent and received on the network for internal cluster communication.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_cluster_connections" {
+  name = "The number of open tcp connections for internal cluster communication."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.cluster.connections").publish(label="The number of open tcp connections for internal cluster communication.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_http_connections" {
+  name = "The number of HTTP connections to the node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.http.connections").publish(label="The number of HTTP connections to the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_operations_current" {
+  name = "Number of query operations currently running."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.operations.current").publish(label="Number of query operations currently running.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_operations_completed" {
+  name = "The number of operations completed by a node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.operations.completed").publish(label="The number of operations completed by a node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_operations_time" {
+  name = "Time spent on operations by a node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.operations.time").publish(label="Time spent on operations by a node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_operations_get_completed" {
+  name = "The number of hits and misses resulting from GET operations."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.operations.get.completed").publish(label="The number of hits and misses resulting from GET operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_operations_get_time" {
+  name = "The time spent on hits and misses resulting from GET operations."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.operations.get.time").publish(label="The time spent on hits and misses resulting from GET operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_shards_size" {
+  name = "The size of the shards assigned to this node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.shards.size").publish(label="The size of the shards assigned to this node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_shards_data_set_size" {
+  name = "Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.shards.data_set.size").publish(label="Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_shards_reserved_size" {
+  name = "A prediction of how much larger the shard stores on this node will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities. A value of -1 indicates that this is not available."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.shards.reserved.size").publish(label="A prediction of how much larger the shard stores on this node will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities. A value of -1 indicates that this is not available.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_translog_operations" {
+  name = "Number of transaction log operations."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.translog.operations").publish(label="Number of transaction log operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_translog_size" {
+  name = "Size of the transaction log."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.translog.size").publish(label="Size of the transaction log.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_translog_uncommitted_size" {
+  name = "Size of uncommitted transaction log operations."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.translog.uncommitted.size").publish(label="Size of uncommitted transaction log operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_thread_pool_threads" {
+  name = "The number of threads in the thread pool."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.thread_pool.threads").publish(label="The number of threads in the thread pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_thread_pool_tasks_queued" {
+  name = "The number of queued tasks in the thread pool."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.thread_pool.tasks.queued").publish(label="The number of queued tasks in the thread pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_thread_pool_tasks_finished" {
+  name = "The number of tasks finished by the thread pool."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.thread_pool.tasks.finished").publish(label="The number of tasks finished by the thread pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_documents" {
+  name = "The number of documents on the node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.documents").publish(label="The number of documents on the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_open_files" {
+  name = "The number of open file descriptors held by the node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.open_files").publish(label="The number of open file descriptors held by the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_classes_loaded" {
+  name = "The number of loaded classes"
+
+  program_text = <<-EOF
+    data("jvm.classes.loaded").publish(label="The number of loaded classes")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_gc_collections_count" {
+  name = "The total number of garbage collections that have occurred"
+
+  program_text = <<-EOF
+    data("jvm.gc.collections.count").publish(label="The total number of garbage collections that have occurred")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_gc_collections_elapsed" {
+  name = "The approximate accumulated collection elapsed time"
+
+  program_text = <<-EOF
+    data("jvm.gc.collections.elapsed").publish(label="The approximate accumulated collection elapsed time")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_memory_heap_max" {
+  name = "The maximum amount of memory can be used for the heap"
+
+  program_text = <<-EOF
+    data("jvm.memory.heap.max").publish(label="The maximum amount of memory can be used for the heap")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_memory_heap_used" {
+  name = "The current heap memory usage"
+
+  program_text = <<-EOF
+    data("jvm.memory.heap.used").publish(label="The current heap memory usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_memory_heap_utilization" {
+  name = "Fraction of heap memory usage"
+
+  program_text = <<-EOF
+    data("jvm.memory.heap.utilization").publish(label="Fraction of heap memory usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_memory_heap_committed" {
+  name = "The amount of memory that is guaranteed to be available for the heap"
+
+  program_text = <<-EOF
+    data("jvm.memory.heap.committed").publish(label="The amount of memory that is guaranteed to be available for the heap")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_memory_nonheap_used" {
+  name = "The current non-heap memory usage"
+
+  program_text = <<-EOF
+    data("jvm.memory.nonheap.used").publish(label="The current non-heap memory usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_memory_nonheap_committed" {
+  name = "The amount of memory that is guaranteed to be available for non-heap purposes"
+
+  program_text = <<-EOF
+    data("jvm.memory.nonheap.committed").publish(label="The amount of memory that is guaranteed to be available for non-heap purposes")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_memory_pool_max" {
+  name = "The maximum amount of memory can be used for the memory pool"
+
+  program_text = <<-EOF
+    data("jvm.memory.pool.max").publish(label="The maximum amount of memory can be used for the memory pool")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_memory_pool_used" {
+  name = "The current memory pool memory usage"
+
+  program_text = <<-EOF
+    data("jvm.memory.pool.used").publish(label="The current memory pool memory usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "jvm_threads_count" {
+  name = "The current number of threads"
+
+  program_text = <<-EOF
+    data("jvm.threads.count").publish(label="The current number of threads")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_pending_tasks" {
+  name = "The number of cluster-level changes that have not yet been executed."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.pending_tasks").publish(label="The number of cluster-level changes that have not yet been executed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_in_flight_fetch" {
+  name = "The number of unfinished fetches."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.in_flight_fetch").publish(label="The number of unfinished fetches.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_shards" {
+  name = "The number of shards in the cluster."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.shards").publish(label="The number of shards in the cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_data_nodes" {
+  name = "The number of data nodes in the cluster."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.data_nodes").publish(label="The number of data nodes in the cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_nodes" {
+  name = "The total number of nodes in the cluster."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.nodes").publish(label="The total number of nodes in the cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_health" {
+  name = "The health status of the cluster."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.health").publish(label="The health status of the cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_os_cpu_usage" {
+  name = "Recent CPU usage for the whole system, or -1 if not supported."
+
+  program_text = <<-EOF
+    data("elasticsearch.os.cpu.usage").publish(label="Recent CPU usage for the whole system, or -1 if not supported.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_os_cpu_load_avg_1m" {
+  name = "One-minute load average on the system (field is not present if one-minute load average is not available)."
+
+  program_text = <<-EOF
+    data("elasticsearch.os.cpu.load_avg.1m").publish(label="One-minute load average on the system (field is not present if one-minute load average is not available).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_os_cpu_load_avg_5m" {
+  name = "Five-minute load average on the system (field is not present if five-minute load average is not available)."
+
+  program_text = <<-EOF
+    data("elasticsearch.os.cpu.load_avg.5m").publish(label="Five-minute load average on the system (field is not present if five-minute load average is not available).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_os_cpu_load_avg_15m" {
+  name = "Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available)."
+
+  program_text = <<-EOF
+    data("elasticsearch.os.cpu.load_avg.15m").publish(label="Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_os_memory" {
+  name = "Amount of physical memory."
+
+  program_text = <<-EOF
+    data("elasticsearch.os.memory").publish(label="Amount of physical memory.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_memory_indexing_pressure" {
+  name = "Memory consumed, in bytes, by indexing requests in the specified stage."
+
+  program_text = <<-EOF
+    data("elasticsearch.memory.indexing_pressure").publish(label="Memory consumed, in bytes, by indexing requests in the specified stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_indexing_pressure_memory_total_primary_rejections" {
+  name = "Cumulative number of indexing requests rejected in the primary stage."
+
+  program_text = <<-EOF
+    data("elasticsearch.indexing_pressure.memory.total.primary_rejections").publish(label="Cumulative number of indexing requests rejected in the primary stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_indexing_pressure_memory_total_replica_rejections" {
+  name = "Number of indexing requests rejected in the replica stage."
+
+  program_text = <<-EOF
+    data("elasticsearch.indexing_pressure.memory.total.replica_rejections").publish(label="Number of indexing requests rejected in the replica stage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_indexing_pressure_memory_limit" {
+  name = "Configured memory limit, in bytes, for the indexing requests."
+
+  program_text = <<-EOF
+    data("elasticsearch.indexing_pressure.memory.limit").publish(label="Configured memory limit, in bytes, for the indexing requests.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_state_queue" {
+  name = "Number of cluster states in queue."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.state_queue").publish(label="Number of cluster states in queue.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_published_states_full" {
+  name = "Number of published cluster states."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.published_states.full").publish(label="Number of published cluster states.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_published_states_differences" {
+  name = "Number of differences between published cluster states."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.published_states.differences").publish(label="Number of differences between published cluster states.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_state_update_count" {
+  name = "The number of cluster state update attempts that changed the cluster state since the node started."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.state_update.count").publish(label="The number of cluster state update attempts that changed the cluster state since the node started.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_state_update_time" {
+  name = "The cumulative amount of time updating the cluster state since the node started."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.state_update.time").publish(label="The cumulative amount of time updating the cluster state since the node started.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_cluster_indices_cache_evictions" {
+  name = "The number of evictions from the cache for indices in cluster."
+
+  program_text = <<-EOF
+    data("elasticsearch.cluster.indices.cache.evictions").publish(label="The number of evictions from the cache for indices in cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_ingest_documents" {
+  name = "Total number of documents ingested during the lifetime of this node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.ingest.documents").publish(label="Total number of documents ingested during the lifetime of this node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_ingest_documents_current" {
+  name = "Total number of documents currently being ingested."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.ingest.documents.current").publish(label="Total number of documents currently being ingested.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_ingest_operations_failed" {
+  name = "Total number of failed ingest operations during the lifetime of this node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.ingest.operations.failed").publish(label="Total number of failed ingest operations during the lifetime of this node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_pipeline_ingest_documents_preprocessed" {
+  name = "Number of documents preprocessed by the ingest pipeline."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.pipeline.ingest.documents.preprocessed").publish(label="Number of documents preprocessed by the ingest pipeline.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_pipeline_ingest_operations_failed" {
+  name = "Total number of failed operations for the ingest pipeline."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.pipeline.ingest.operations.failed").publish(label="Total number of failed operations for the ingest pipeline.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_pipeline_ingest_documents_current" {
+  name = "Total number of documents currently being ingested by a pipeline."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.pipeline.ingest.documents.current").publish(label="Total number of documents currently being ingested by a pipeline.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_script_compilations" {
+  name = "Total number of inline script compilations performed by the node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.script.compilations").publish(label="Total number of inline script compilations performed by the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_script_cache_evictions" {
+  name = "Total number of times the script cache has evicted old data."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.script.cache_evictions").publish(label="Total number of times the script cache has evicted old data.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_script_compilation_limit_triggered" {
+  name = "Total number of times the script compilation circuit breaker has limited inline script compilations."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.script.compilation_limit_triggered").publish(label="Total number of times the script compilation circuit breaker has limited inline script compilations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_node_segments_memory" {
+  name = "Size of memory for segment object of a node."
+
+  program_text = <<-EOF
+    data("elasticsearch.node.segments.memory").publish(label="Size of memory for segment object of a node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_operations_completed" {
+  name = "The number of operations completed for an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.operations.completed").publish(label="The number of operations completed for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_operations_time" {
+  name = "Time spent on operations for an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.operations.time").publish(label="Time spent on operations for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_shards_size" {
+  name = "The size of the shards assigned to this index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.shards.size").publish(label="The size of the shards assigned to this index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_operations_merge_size" {
+  name = "The total size of merged segments for an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.operations.merge.size").publish(label="The total size of merged segments for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_operations_merge_docs_count" {
+  name = "The total number of documents in merge operations for an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.operations.merge.docs_count").publish(label="The total number of documents in merge operations for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_segments_count" {
+  name = "Number of segments of an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.segments.count").publish(label="Number of segments of an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_segments_size" {
+  name = "Size of segments of an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.segments.size").publish(label="Size of segments of an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_segments_memory" {
+  name = "Size of memory for segment object of an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.segments.memory").publish(label="Size of memory for segment object of an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_translog_operations" {
+  name = "Number of transaction log operations for an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.translog.operations").publish(label="Number of transaction log operations for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_translog_size" {
+  name = "Size of the transaction log for an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.translog.size").publish(label="Size of the transaction log for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_cache_memory_usage" {
+  name = "The size in bytes of the cache for an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.cache.memory.usage").publish(label="The size in bytes of the cache for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_cache_size" {
+  name = "The number of elements of the query cache for an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.cache.size").publish(label="The number of elements of the query cache for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_cache_evictions" {
+  name = "The number of evictions from the cache for an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.cache.evictions").publish(label="The number of evictions from the cache for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_index_documents" {
+  name = "The number of documents for an index."
+
+  program_text = <<-EOF
+    data("elasticsearch.index.documents").publish(label="The number of documents for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_process_cpu_usage" {
+  name = "CPU usage in percent."
+
+  program_text = <<-EOF
+    data("elasticsearch.process.cpu.usage").publish(label="CPU usage in percent.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_process_cpu_time" {
+  name = "CPU time used by the process on which the Java virtual machine is running."
+
+  program_text = <<-EOF
+    data("elasticsearch.process.cpu.time").publish(label="CPU time used by the process on which the Java virtual machine is running.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "elasticsearch_process_memory_virtual" {
+  name = "Size of virtual memory that is guaranteed to be available to the running process."
+
+  program_text = <<-EOF
+    data("elasticsearch.process.memory.virtual").publish(label="Size of virtual memory that is guaranteed to be available to the running process.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/expvarreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/expvarreceiver_metadata.yaml.tf
@@ -1,0 +1,382 @@
+
+resource "signalfx_dashboard" "expvardashboard" {
+  name            = "expvar"
+  dashboard_group = signalfx_dashboard_group.expvardashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.process_runtime_memstats_total_alloc.id, signalfx_time_chart.process_runtime_memstats_sys.id, signalfx_time_chart.process_runtime_memstats_lookups.id, signalfx_time_chart.process_runtime_memstats_mallocs.id, signalfx_time_chart.process_runtime_memstats_frees.id, signalfx_time_chart.process_runtime_memstats_heap_alloc.id, signalfx_time_chart.process_runtime_memstats_heap_sys.id, signalfx_time_chart.process_runtime_memstats_heap_idle.id, signalfx_time_chart.process_runtime_memstats_heap_inuse.id, signalfx_time_chart.process_runtime_memstats_heap_released.id, signalfx_time_chart.process_runtime_memstats_heap_objects.id, signalfx_time_chart.process_runtime_memstats_stack_inuse.id, signalfx_time_chart.process_runtime_memstats_stack_sys.id, signalfx_time_chart.process_runtime_memstats_mspan_inuse.id, signalfx_time_chart.process_runtime_memstats_mspan_sys.id, signalfx_time_chart.process_runtime_memstats_mcache_inuse.id, signalfx_time_chart.process_runtime_memstats_mcache_sys.id, signalfx_time_chart.process_runtime_memstats_buck_hash_sys.id, signalfx_time_chart.process_runtime_memstats_gc_sys.id, signalfx_time_chart.process_runtime_memstats_other_sys.id, signalfx_time_chart.process_runtime_memstats_next_gc.id, signalfx_time_chart.process_runtime_memstats_pause_total.id, signalfx_time_chart.process_runtime_memstats_last_pause.id, signalfx_time_chart.process_runtime_memstats_num_gc.id, signalfx_time_chart.process_runtime_memstats_num_forced_gc.id, signalfx_time_chart.process_runtime_memstats_gc_cpu_fraction.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "expvardashboardgroup0" {
+  name        = "expvar generated OTel dashboard group"
+  description = "expvar generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "process_runtime_memstats_total_alloc" {
+  name = "Cumulative bytes allocated for heap objects."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.total_alloc").publish(label="Cumulative bytes allocated for heap objects.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_sys" {
+  name = "Total bytes of memory obtained from the OS."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.sys").publish(label="Total bytes of memory obtained from the OS.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_lookups" {
+  name = "Number of pointer lookups performed by the runtime."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.lookups").publish(label="Number of pointer lookups performed by the runtime.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_mallocs" {
+  name = "Cumulative count of heap objects allocated."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.mallocs").publish(label="Cumulative count of heap objects allocated.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_frees" {
+  name = "Cumulative count of heap objects freed."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.frees").publish(label="Cumulative count of heap objects freed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_heap_alloc" {
+  name = "Bytes of allocated heap objects."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.heap_alloc").publish(label="Bytes of allocated heap objects.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_heap_sys" {
+  name = "Bytes of heap memory obtained by the OS."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.heap_sys").publish(label="Bytes of heap memory obtained by the OS.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_heap_idle" {
+  name = "Bytes in idle (unused) spans."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.heap_idle").publish(label="Bytes in idle (unused) spans.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_heap_inuse" {
+  name = "Bytes in in-use spans."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.heap_inuse").publish(label="Bytes in in-use spans.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_heap_released" {
+  name = "Bytes of physical memory returned to the OS."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.heap_released").publish(label="Bytes of physical memory returned to the OS.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_heap_objects" {
+  name = "Number of allocated heap objects."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.heap_objects").publish(label="Number of allocated heap objects.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_stack_inuse" {
+  name = "Bytes in stack spans."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.stack_inuse").publish(label="Bytes in stack spans.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_stack_sys" {
+  name = "Bytes of stack memory obtained from the OS."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.stack_sys").publish(label="Bytes of stack memory obtained from the OS.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_mspan_inuse" {
+  name = "Bytes of allocated mspan structures."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.mspan_inuse").publish(label="Bytes of allocated mspan structures.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_mspan_sys" {
+  name = "Bytes of memory obtained from the OS for mspan structures."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.mspan_sys").publish(label="Bytes of memory obtained from the OS for mspan structures.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_mcache_inuse" {
+  name = "Bytes of allocated mcache structures."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.mcache_inuse").publish(label="Bytes of allocated mcache structures.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_mcache_sys" {
+  name = "Bytes of memory obtained from the OS for mcache structures."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.mcache_sys").publish(label="Bytes of memory obtained from the OS for mcache structures.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_buck_hash_sys" {
+  name = "Bytes of memory in profiling bucket hash tables."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.buck_hash_sys").publish(label="Bytes of memory in profiling bucket hash tables.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_gc_sys" {
+  name = "Bytes of memory in garbage collection metadata."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.gc_sys").publish(label="Bytes of memory in garbage collection metadata.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_other_sys" {
+  name = "Bytes of memory in miscellaneous off-heap runtime allocations."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.other_sys").publish(label="Bytes of memory in miscellaneous off-heap runtime allocations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_next_gc" {
+  name = "The target heap size of the next GC cycle."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.next_gc").publish(label="The target heap size of the next GC cycle.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_pause_total" {
+  name = "The cumulative nanoseconds in GC stop-the-world pauses since the program started."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.pause_total").publish(label="The cumulative nanoseconds in GC stop-the-world pauses since the program started.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_last_pause" {
+  name = "The most recent stop-the-world pause time."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.last_pause").publish(label="The most recent stop-the-world pause time.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_num_gc" {
+  name = "Number of completed GC cycles."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.num_gc").publish(label="Number of completed GC cycles.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_num_forced_gc" {
+  name = "Number of GC cycles that were forced by the application calling the GC function."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.num_forced_gc").publish(label="Number of GC cycles that were forced by the application calling the GC function.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "process_runtime_memstats_gc_cpu_fraction" {
+  name = "The fraction of this program's available CPU time used by the GC since the program started."
+
+  program_text = <<-EOF
+    data("process.runtime.memstats.gc_cpu_fraction").publish(label="The fraction of this program's available CPU time used by the GC since the program started.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/filestatsreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/filestatsreceiver_metadata.yaml.tf
@@ -1,0 +1,74 @@
+
+resource "signalfx_dashboard" "filestatsdashboard" {
+  name            = "filestats"
+  dashboard_group = signalfx_dashboard_group.filestatsdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.file_mtime.id, signalfx_time_chart.file_ctime.id, signalfx_time_chart.file_atime.id, signalfx_time_chart.file_size.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "filestatsdashboardgroup0" {
+  name        = "filestats generated OTel dashboard group"
+  description = "filestats generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "file_mtime" {
+  name = "Elapsed time since the last modification of the file or folder, in seconds since Epoch."
+
+  program_text = <<-EOF
+    data("file.mtime").publish(label="Elapsed time since the last modification of the file or folder, in seconds since Epoch.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "file_ctime" {
+  name = "Elapsed time since the last change of the file or folder, in seconds since Epoch. In addition to `file.mtime`, this metric tracks metadata changes such as permissions or renaming the file."
+
+  program_text = <<-EOF
+    data("file.ctime").publish(label="Elapsed time since the last change of the file or folder, in seconds since Epoch. In addition to `file.mtime`, this metric tracks metadata changes such as permissions or renaming the file.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "file_atime" {
+  name = "Elapsed time since last access of the file or folder, in seconds since Epoch."
+
+  program_text = <<-EOF
+    data("file.atime").publish(label="Elapsed time since last access of the file or folder, in seconds since Epoch.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "file_size" {
+  name = "The size of the file or folder, in bytes."
+
+  program_text = <<-EOF
+    data("file.size").publish(label="The size of the file or folder, in bytes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/flinkmetricsreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/flinkmetricsreceiver_metadata.yaml.tf
@@ -1,0 +1,424 @@
+
+resource "signalfx_dashboard" "flinkmetricsdashboard" {
+  name            = "flinkmetrics"
+  dashboard_group = signalfx_dashboard_group.flinkmetricsdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.flink_jvm_cpu_load.id, signalfx_time_chart.flink_jvm_cpu_time.id, signalfx_time_chart.flink_jvm_memory_heap_used.id, signalfx_time_chart.flink_jvm_memory_heap_committed.id, signalfx_time_chart.flink_jvm_memory_heap_max.id, signalfx_time_chart.flink_jvm_memory_nonheap_used.id, signalfx_time_chart.flink_jvm_memory_nonheap_committed.id, signalfx_time_chart.flink_jvm_memory_nonheap_max.id, signalfx_time_chart.flink_jvm_memory_metaspace_used.id, signalfx_time_chart.flink_jvm_memory_metaspace_committed.id, signalfx_time_chart.flink_jvm_memory_metaspace_max.id, signalfx_time_chart.flink_jvm_memory_direct_used.id, signalfx_time_chart.flink_jvm_memory_direct_total_capacity.id, signalfx_time_chart.flink_jvm_memory_mapped_used.id, signalfx_time_chart.flink_jvm_memory_mapped_total_capacity.id, signalfx_time_chart.flink_memory_managed_used.id, signalfx_time_chart.flink_memory_managed_total.id, signalfx_time_chart.flink_jvm_threads_count.id, signalfx_time_chart.flink_jvm_gc_collections_count.id, signalfx_time_chart.flink_jvm_gc_collections_time.id, signalfx_time_chart.flink_jvm_class_loader_classes_loaded.id, signalfx_time_chart.flink_job_restart_count.id, signalfx_time_chart.flink_job_last_checkpoint_time.id, signalfx_time_chart.flink_job_last_checkpoint_size.id, signalfx_time_chart.flink_job_checkpoint_count.id, signalfx_time_chart.flink_job_checkpoint_in_progress.id, signalfx_time_chart.flink_task_record_count.id, signalfx_time_chart.flink_operator_record_count.id, signalfx_time_chart.flink_operator_watermark_output.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "flinkmetricsdashboardgroup0" {
+  name        = "flinkmetrics generated OTel dashboard group"
+  description = "flinkmetrics generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "flink_jvm_cpu_load" {
+  name = "The CPU usage of the JVM for a jobmanager or taskmanager."
+
+  program_text = <<-EOF
+    data("flink.jvm.cpu.load").publish(label="The CPU usage of the JVM for a jobmanager or taskmanager.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_cpu_time" {
+  name = "The CPU time used by the JVM for a jobmanager or taskmanager."
+
+  program_text = <<-EOF
+    data("flink.jvm.cpu.time").publish(label="The CPU time used by the JVM for a jobmanager or taskmanager.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_heap_used" {
+  name = "The amount of heap memory currently used."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.heap.used").publish(label="The amount of heap memory currently used.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_heap_committed" {
+  name = "The amount of heap memory guaranteed to be available to the JVM."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.heap.committed").publish(label="The amount of heap memory guaranteed to be available to the JVM.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_heap_max" {
+  name = "The maximum amount of heap memory that can be used for memory management."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.heap.max").publish(label="The maximum amount of heap memory that can be used for memory management.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_nonheap_used" {
+  name = "The amount of non-heap memory currently used."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.nonheap.used").publish(label="The amount of non-heap memory currently used.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_nonheap_committed" {
+  name = "The amount of non-heap memory guaranteed to be available to the JVM."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.nonheap.committed").publish(label="The amount of non-heap memory guaranteed to be available to the JVM.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_nonheap_max" {
+  name = "The maximum amount of non-heap memory that can be used for memory management."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.nonheap.max").publish(label="The maximum amount of non-heap memory that can be used for memory management.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_metaspace_used" {
+  name = "The amount of memory currently used in the Metaspace memory pool."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.metaspace.used").publish(label="The amount of memory currently used in the Metaspace memory pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_metaspace_committed" {
+  name = "The amount of memory guaranteed to be available to the JVM in the Metaspace memory pool."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.metaspace.committed").publish(label="The amount of memory guaranteed to be available to the JVM in the Metaspace memory pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_metaspace_max" {
+  name = "The maximum amount of memory that can be used in the Metaspace memory pool."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.metaspace.max").publish(label="The maximum amount of memory that can be used in the Metaspace memory pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_direct_used" {
+  name = "The amount of memory used by the JVM for the direct buffer pool."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.direct.used").publish(label="The amount of memory used by the JVM for the direct buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_direct_total_capacity" {
+  name = "The total capacity of all buffers in the direct buffer pool."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.direct.total_capacity").publish(label="The total capacity of all buffers in the direct buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_mapped_used" {
+  name = "The amount of memory used by the JVM for the mapped buffer pool."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.mapped.used").publish(label="The amount of memory used by the JVM for the mapped buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_memory_mapped_total_capacity" {
+  name = "The number of buffers in the mapped buffer pool."
+
+  program_text = <<-EOF
+    data("flink.jvm.memory.mapped.total_capacity").publish(label="The number of buffers in the mapped buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_memory_managed_used" {
+  name = "The amount of managed memory currently used."
+
+  program_text = <<-EOF
+    data("flink.memory.managed.used").publish(label="The amount of managed memory currently used.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_memory_managed_total" {
+  name = "The total amount of managed memory."
+
+  program_text = <<-EOF
+    data("flink.memory.managed.total").publish(label="The total amount of managed memory.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_threads_count" {
+  name = "The total number of live threads."
+
+  program_text = <<-EOF
+    data("flink.jvm.threads.count").publish(label="The total number of live threads.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_gc_collections_count" {
+  name = "The total number of collections that have occurred."
+
+  program_text = <<-EOF
+    data("flink.jvm.gc.collections.count").publish(label="The total number of collections that have occurred.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_gc_collections_time" {
+  name = "The total time spent performing garbage collection."
+
+  program_text = <<-EOF
+    data("flink.jvm.gc.collections.time").publish(label="The total time spent performing garbage collection.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_jvm_class_loader_classes_loaded" {
+  name = "The total number of classes loaded since the start of the JVM."
+
+  program_text = <<-EOF
+    data("flink.jvm.class_loader.classes_loaded").publish(label="The total number of classes loaded since the start of the JVM.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_job_restart_count" {
+  name = "The total number of restarts since this job was submitted, including full restarts and fine-grained restarts."
+
+  program_text = <<-EOF
+    data("flink.job.restart.count").publish(label="The total number of restarts since this job was submitted, including full restarts and fine-grained restarts.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_job_last_checkpoint_time" {
+  name = "The end to end duration of the last checkpoint."
+
+  program_text = <<-EOF
+    data("flink.job.last_checkpoint.time").publish(label="The end to end duration of the last checkpoint.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_job_last_checkpoint_size" {
+  name = "The total size of the last checkpoint."
+
+  program_text = <<-EOF
+    data("flink.job.last_checkpoint.size").publish(label="The total size of the last checkpoint.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_job_checkpoint_count" {
+  name = "The number of checkpoints completed or failed."
+
+  program_text = <<-EOF
+    data("flink.job.checkpoint.count").publish(label="The number of checkpoints completed or failed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_job_checkpoint_in_progress" {
+  name = "The number of checkpoints in progress."
+
+  program_text = <<-EOF
+    data("flink.job.checkpoint.in_progress").publish(label="The number of checkpoints in progress.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_task_record_count" {
+  name = "The number of records a task has."
+
+  program_text = <<-EOF
+    data("flink.task.record.count").publish(label="The number of records a task has.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_operator_record_count" {
+  name = "The number of records an operator has."
+
+  program_text = <<-EOF
+    data("flink.operator.record.count").publish(label="The number of records an operator has.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "flink_operator_watermark_output" {
+  name = "The last watermark this operator has emitted."
+
+  program_text = <<-EOF
+    data("flink.operator.watermark.output").publish(label="The last watermark this operator has emitted.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/gitproviderreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/gitproviderreceiver_metadata.yaml.tf
@@ -1,0 +1,60 @@
+
+resource "signalfx_dashboard" "gitproviderdashboard" {
+  name            = "gitprovider"
+  dashboard_group = signalfx_dashboard_group.gitproviderdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.git_repository_count.id, signalfx_time_chart.git_repository_branch_count.id, signalfx_time_chart.git_repository_contributor_count.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "gitproviderdashboardgroup0" {
+  name        = "gitprovider generated OTel dashboard group"
+  description = "gitprovider generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "git_repository_count" {
+  name = "Number of repositories in an organization"
+
+  program_text = <<-EOF
+    data("git.repository.count").publish(label="Number of repositories in an organization")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "git_repository_branch_count" {
+  name = "Number of branches in the repository"
+
+  program_text = <<-EOF
+    data("git.repository.branch.count").publish(label="Number of branches in the repository")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "git_repository_contributor_count" {
+  name = "Total number of unique contributors to this repository"
+
+  program_text = <<-EOF
+    data("git.repository.contributor.count").publish(label="Total number of unique contributors to this repository")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/haproxyreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/haproxyreceiver_metadata.yaml.tf
@@ -1,0 +1,382 @@
+
+resource "signalfx_dashboard" "haproxydashboard" {
+  name            = "haproxy"
+  dashboard_group = signalfx_dashboard_group.haproxydashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.haproxy_connections_rate.id, signalfx_time_chart.haproxy_sessions_count.id, signalfx_time_chart.haproxy_connections_total.id, signalfx_time_chart.haproxy_server_selected_total.id, signalfx_time_chart.haproxy_bytes_input.id, signalfx_time_chart.haproxy_bytes_output.id, signalfx_time_chart.haproxy_clients_canceled.id, signalfx_time_chart.haproxy_compression_bypass.id, signalfx_time_chart.haproxy_compression_input.id, signalfx_time_chart.haproxy_compression_output.id, signalfx_time_chart.haproxy_compression_count.id, signalfx_time_chart.haproxy_requests_denied.id, signalfx_time_chart.haproxy_responses_denied.id, signalfx_time_chart.haproxy_downtime.id, signalfx_time_chart.haproxy_connections_errors.id, signalfx_time_chart.haproxy_requests_errors.id, signalfx_time_chart.haproxy_responses_errors.id, signalfx_time_chart.haproxy_failed_checks.id, signalfx_time_chart.haproxy_requests_redispatched.id, signalfx_time_chart.haproxy_requests_total.id, signalfx_time_chart.haproxy_connections_retries.id, signalfx_time_chart.haproxy_sessions_total.id, signalfx_time_chart.haproxy_requests_queued.id, signalfx_time_chart.haproxy_requests_rate.id, signalfx_time_chart.haproxy_sessions_average.id, signalfx_time_chart.haproxy_sessions_rate.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "haproxydashboardgroup0" {
+  name        = "haproxy generated OTel dashboard group"
+  description = "haproxy generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "haproxy_connections_rate" {
+  name = "Number of connections over the last elapsed second (frontend). Corresponds to HAProxy's `conn_rate` metric."
+
+  program_text = <<-EOF
+    data("haproxy.connections.rate").publish(label="Number of connections over the last elapsed second (frontend). Corresponds to HAProxy's `conn_rate` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_sessions_count" {
+  name = "Current sessions. Corresponds to HAProxy's `scur` metric."
+
+  program_text = <<-EOF
+    data("haproxy.sessions.count").publish(label="Current sessions. Corresponds to HAProxy's `scur` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_connections_total" {
+  name = "Cumulative number of connections (frontend). Corresponds to HAProxy's `conn_tot` metric."
+
+  program_text = <<-EOF
+    data("haproxy.connections.total").publish(label="Cumulative number of connections (frontend). Corresponds to HAProxy's `conn_tot` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_server_selected_total" {
+  name = "Number of times a server was selected, either for new sessions or when re-dispatching. Corresponds to HAProxy's `lbtot` metric."
+
+  program_text = <<-EOF
+    data("haproxy.server_selected.total").publish(label="Number of times a server was selected, either for new sessions or when re-dispatching. Corresponds to HAProxy's `lbtot` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_bytes_input" {
+  name = "Bytes in. Corresponds to HAProxy's `bin` metric."
+
+  program_text = <<-EOF
+    data("haproxy.bytes.input").publish(label="Bytes in. Corresponds to HAProxy's `bin` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_bytes_output" {
+  name = "Bytes out. Corresponds to HAProxy's `bout` metric."
+
+  program_text = <<-EOF
+    data("haproxy.bytes.output").publish(label="Bytes out. Corresponds to HAProxy's `bout` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_clients_canceled" {
+  name = "Number of data transfers aborted by the client. Corresponds to HAProxy's `cli_abrt` metric"
+
+  program_text = <<-EOF
+    data("haproxy.clients.canceled").publish(label="Number of data transfers aborted by the client. Corresponds to HAProxy's `cli_abrt` metric")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_compression_bypass" {
+  name = "Number of bytes that bypassed the HTTP compressor (CPU/BW limit). Corresponds to HAProxy's `comp_byp` metric."
+
+  program_text = <<-EOF
+    data("haproxy.compression.bypass").publish(label="Number of bytes that bypassed the HTTP compressor (CPU/BW limit). Corresponds to HAProxy's `comp_byp` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_compression_input" {
+  name = "Number of HTTP response bytes fed to the compressor. Corresponds to HAProxy's `comp_in` metric."
+
+  program_text = <<-EOF
+    data("haproxy.compression.input").publish(label="Number of HTTP response bytes fed to the compressor. Corresponds to HAProxy's `comp_in` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_compression_output" {
+  name = "Number of HTTP response bytes emitted by the compressor. Corresponds to HAProxy's `comp_out` metric."
+
+  program_text = <<-EOF
+    data("haproxy.compression.output").publish(label="Number of HTTP response bytes emitted by the compressor. Corresponds to HAProxy's `comp_out` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_compression_count" {
+  name = "Number of HTTP responses that were compressed. Corresponds to HAProxy's `comp_rsp` metric."
+
+  program_text = <<-EOF
+    data("haproxy.compression.count").publish(label="Number of HTTP responses that were compressed. Corresponds to HAProxy's `comp_rsp` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_requests_denied" {
+  name = "Requests denied because of security concerns. Corresponds to HAProxy's `dreq` metric"
+
+  program_text = <<-EOF
+    data("haproxy.requests.denied").publish(label="Requests denied because of security concerns. Corresponds to HAProxy's `dreq` metric")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_responses_denied" {
+  name = "Responses denied because of security concerns. Corresponds to HAProxy's `dresp` metric"
+
+  program_text = <<-EOF
+    data("haproxy.responses.denied").publish(label="Responses denied because of security concerns. Corresponds to HAProxy's `dresp` metric")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_downtime" {
+  name = "Total downtime (in seconds). The value for the backend is the downtime for the whole backend, not the sum of the server downtime. Corresponds to HAProxy's `downtime` metric"
+
+  program_text = <<-EOF
+    data("haproxy.downtime").publish(label="Total downtime (in seconds). The value for the backend is the downtime for the whole backend, not the sum of the server downtime. Corresponds to HAProxy's `downtime` metric")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_connections_errors" {
+  name = "Number of requests that encountered an error trying to connect to a backend server. The backend stat is the sum of the stat. Corresponds to HAProxy's `econ` metric"
+
+  program_text = <<-EOF
+    data("haproxy.connections.errors").publish(label="Number of requests that encountered an error trying to connect to a backend server. The backend stat is the sum of the stat. Corresponds to HAProxy's `econ` metric")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_requests_errors" {
+  name = "Cumulative number of request errors. Corresponds to HAProxy's `ereq` metric."
+
+  program_text = <<-EOF
+    data("haproxy.requests.errors").publish(label="Cumulative number of request errors. Corresponds to HAProxy's `ereq` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_responses_errors" {
+  name = "Cumulative number of response errors. Corresponds to HAProxy's `eresp` metric, `srv_abrt` will be counted here also."
+
+  program_text = <<-EOF
+    data("haproxy.responses.errors").publish(label="Cumulative number of response errors. Corresponds to HAProxy's `eresp` metric, `srv_abrt` will be counted here also.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_failed_checks" {
+  name = "Number of failed checks. (Only counts checks failed when the server is up). Corresponds to HAProxy's `chkfail` metric."
+
+  program_text = <<-EOF
+    data("haproxy.failed_checks").publish(label="Number of failed checks. (Only counts checks failed when the server is up). Corresponds to HAProxy's `chkfail` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_requests_redispatched" {
+  name = "Number of times a request was redispatched to another server. Corresponds to HAProxy's `wredis` metric."
+
+  program_text = <<-EOF
+    data("haproxy.requests.redispatched").publish(label="Number of times a request was redispatched to another server. Corresponds to HAProxy's `wredis` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_requests_total" {
+  name = "Total number of HTTP requests received. Corresponds to HAProxy's `req_tot`, `hrsp_1xx`, `hrsp_2xx`, `hrsp_3xx`, `hrsp_4xx`, `hrsp_5xx` and `hrsp_other` metrics."
+
+  program_text = <<-EOF
+    data("haproxy.requests.total").publish(label="Total number of HTTP requests received. Corresponds to HAProxy's `req_tot`, `hrsp_1xx`, `hrsp_2xx`, `hrsp_3xx`, `hrsp_4xx`, `hrsp_5xx` and `hrsp_other` metrics.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_connections_retries" {
+  name = "Number of times a connection to a server was retried. Corresponds to HAProxy's `wretr` metric."
+
+  program_text = <<-EOF
+    data("haproxy.connections.retries").publish(label="Number of times a connection to a server was retried. Corresponds to HAProxy's `wretr` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_sessions_total" {
+  name = "Cumulative number of sessions. Corresponds to HAProxy's `stot` metric."
+
+  program_text = <<-EOF
+    data("haproxy.sessions.total").publish(label="Cumulative number of sessions. Corresponds to HAProxy's `stot` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_requests_queued" {
+  name = "Current queued requests. For the backend this reports the number queued without a server assigned. Corresponds to HAProxy's `qcur` metric."
+
+  program_text = <<-EOF
+    data("haproxy.requests.queued").publish(label="Current queued requests. For the backend this reports the number queued without a server assigned. Corresponds to HAProxy's `qcur` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_requests_rate" {
+  name = "HTTP requests per second over last elapsed second. Corresponds to HAProxy's `req_rate` metric."
+
+  program_text = <<-EOF
+    data("haproxy.requests.rate").publish(label="HTTP requests per second over last elapsed second. Corresponds to HAProxy's `req_rate` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_sessions_average" {
+  name = "Average total session time in ms over the last 1024 requests. Corresponds to HAProxy's `ttime` metric."
+
+  program_text = <<-EOF
+    data("haproxy.sessions.average").publish(label="Average total session time in ms over the last 1024 requests. Corresponds to HAProxy's `ttime` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "haproxy_sessions_rate" {
+  name = "Number of sessions per second over last elapsed second. Corresponds to HAProxy's `rate` metric."
+
+  program_text = <<-EOF
+    data("haproxy.sessions.rate").publish(label="Number of sessions per second over last elapsed second. Corresponds to HAProxy's `rate` metric.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/httpcheckreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/httpcheckreceiver_metadata.yaml.tf
@@ -1,0 +1,60 @@
+
+resource "signalfx_dashboard" "httpcheckdashboard" {
+  name            = "httpcheck"
+  dashboard_group = signalfx_dashboard_group.httpcheckdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.httpcheck_status.id, signalfx_time_chart.httpcheck_duration.id, signalfx_time_chart.httpcheck_error.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "httpcheckdashboardgroup0" {
+  name        = "httpcheck generated OTel dashboard group"
+  description = "httpcheck generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "httpcheck_status" {
+  name = "1 if the check resulted in status_code matching the status_class, otherwise 0."
+
+  program_text = <<-EOF
+    data("httpcheck.status").publish(label="1 if the check resulted in status_code matching the status_class, otherwise 0.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "httpcheck_duration" {
+  name = "Measures the duration of the HTTP check."
+
+  program_text = <<-EOF
+    data("httpcheck.duration").publish(label="Measures the duration of the HTTP check.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "httpcheck_error" {
+  name = "Records errors occurring during HTTP check."
+
+  program_text = <<-EOF
+    data("httpcheck.error").publish(label="Records errors occurring during HTTP check.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/iisreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/iisreceiver_metadata.yaml.tf
@@ -1,0 +1,186 @@
+
+resource "signalfx_dashboard" "iisdashboard" {
+  name            = "iis"
+  dashboard_group = signalfx_dashboard_group.iisdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.iis_request_count.id, signalfx_time_chart.iis_request_rejected.id, signalfx_time_chart.iis_request_queue_count.id, signalfx_time_chart.iis_request_queue_age_max.id, signalfx_time_chart.iis_network_file_count.id, signalfx_time_chart.iis_network_blocked.id, signalfx_time_chart.iis_network_io.id, signalfx_time_chart.iis_connection_attempt_count.id, signalfx_time_chart.iis_connection_active.id, signalfx_time_chart.iis_connection_anonymous.id, signalfx_time_chart.iis_thread_active.id, signalfx_time_chart.iis_uptime.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "iisdashboardgroup0" {
+  name        = "iis generated OTel dashboard group"
+  description = "iis generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "iis_request_count" {
+  name = "Total number of requests of a given type."
+
+  program_text = <<-EOF
+    data("iis.request.count").publish(label="Total number of requests of a given type.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_request_rejected" {
+  name = "Total number of requests rejected."
+
+  program_text = <<-EOF
+    data("iis.request.rejected").publish(label="Total number of requests rejected.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_request_queue_count" {
+  name = "Current number of requests in the queue."
+
+  program_text = <<-EOF
+    data("iis.request.queue.count").publish(label="Current number of requests in the queue.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_request_queue_age_max" {
+  name = "Age of oldest request in the queue."
+
+  program_text = <<-EOF
+    data("iis.request.queue.age.max").publish(label="Age of oldest request in the queue.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_network_file_count" {
+  name = "Number of transmitted files."
+
+  program_text = <<-EOF
+    data("iis.network.file.count").publish(label="Number of transmitted files.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_network_blocked" {
+  name = "Number of bytes blocked due to bandwidth throttling."
+
+  program_text = <<-EOF
+    data("iis.network.blocked").publish(label="Number of bytes blocked due to bandwidth throttling.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_network_io" {
+  name = "Total amount of bytes sent and received."
+
+  program_text = <<-EOF
+    data("iis.network.io").publish(label="Total amount of bytes sent and received.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_connection_attempt_count" {
+  name = "Total number of attempts to connect to the server."
+
+  program_text = <<-EOF
+    data("iis.connection.attempt.count").publish(label="Total number of attempts to connect to the server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_connection_active" {
+  name = "Number of active connections."
+
+  program_text = <<-EOF
+    data("iis.connection.active").publish(label="Number of active connections.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_connection_anonymous" {
+  name = "Number of connections established anonymously."
+
+  program_text = <<-EOF
+    data("iis.connection.anonymous").publish(label="Number of connections established anonymously.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_thread_active" {
+  name = "Current number of active threads."
+
+  program_text = <<-EOF
+    data("iis.thread.active").publish(label="Current number of active threads.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "iis_uptime" {
+  name = "The amount of time the server has been up."
+
+  program_text = <<-EOF
+    data("iis.uptime").publish(label="The amount of time the server has been up.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/k8sclusterreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/k8sclusterreceiver_metadata.yaml.tf
@@ -1,0 +1,634 @@
+
+resource "signalfx_dashboard" "k8s_clusterdashboard" {
+  name            = "k8s_cluster"
+  dashboard_group = signalfx_dashboard_group.k8s_clusterdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.k8s_container_cpu_request.id, signalfx_time_chart.k8s_container_cpu_limit.id, signalfx_time_chart.k8s_container_memory_request.id, signalfx_time_chart.k8s_container_memory_limit.id, signalfx_time_chart.k8s_container_storage_request.id, signalfx_time_chart.k8s_container_storage_limit.id, signalfx_time_chart.k8s_container_ephemeralstorage_request.id, signalfx_time_chart.k8s_container_ephemeralstorage_limit.id, signalfx_time_chart.k8s_container_restarts.id, signalfx_time_chart.k8s_container_ready.id, signalfx_time_chart.k8s_pod_phase.id, signalfx_time_chart.k8s_pod_status_reason.id, signalfx_time_chart.k8s_deployment_desired.id, signalfx_time_chart.k8s_deployment_available.id, signalfx_time_chart.k8s_cronjob_active_jobs.id, signalfx_time_chart.k8s_daemonset_current_scheduled_nodes.id, signalfx_time_chart.k8s_daemonset_desired_scheduled_nodes.id, signalfx_time_chart.k8s_daemonset_misscheduled_nodes.id, signalfx_time_chart.k8s_daemonset_ready_nodes.id, signalfx_time_chart.k8s_hpa_max_replicas.id, signalfx_time_chart.k8s_hpa_min_replicas.id, signalfx_time_chart.k8s_hpa_current_replicas.id, signalfx_time_chart.k8s_hpa_desired_replicas.id, signalfx_time_chart.k8s_job_active_pods.id, signalfx_time_chart.k8s_job_desired_successful_pods.id, signalfx_time_chart.k8s_job_failed_pods.id, signalfx_time_chart.k8s_job_max_parallel_pods.id, signalfx_time_chart.k8s_job_successful_pods.id, signalfx_time_chart.k8s_namespace_phase.id, signalfx_time_chart.k8s_replicaset_desired.id, signalfx_time_chart.k8s_replicaset_available.id, signalfx_time_chart.k8s_replication_controller_desired.id, signalfx_time_chart.k8s_replication_controller_available.id, signalfx_time_chart.k8s_resource_quota_hard_limit.id, signalfx_time_chart.k8s_resource_quota_used.id, signalfx_time_chart.k8s_statefulset_desired_pods.id, signalfx_time_chart.k8s_statefulset_ready_pods.id, signalfx_time_chart.k8s_statefulset_current_pods.id, signalfx_time_chart.k8s_statefulset_updated_pods.id, signalfx_time_chart.openshift_clusterquota_limit.id, signalfx_time_chart.openshift_clusterquota_used.id, signalfx_time_chart.openshift_appliedclusterquota_limit.id, signalfx_time_chart.openshift_appliedclusterquota_used.id, signalfx_time_chart.k8s_node_condition.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "k8s_clusterdashboardgroup0" {
+  name        = "k8s_cluster generated OTel dashboard group"
+  description = "k8s_cluster generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "k8s_container_cpu_request" {
+  name = "Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details"
+
+  program_text = <<-EOF
+    data("k8s.container.cpu_request").publish(label="Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_cpu_limit" {
+  name = "Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details"
+
+  program_text = <<-EOF
+    data("k8s.container.cpu_limit").publish(label="Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_memory_request" {
+  name = "Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details"
+
+  program_text = <<-EOF
+    data("k8s.container.memory_request").publish(label="Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_memory_limit" {
+  name = "Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details"
+
+  program_text = <<-EOF
+    data("k8s.container.memory_limit").publish(label="Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_storage_request" {
+  name = "Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details"
+
+  program_text = <<-EOF
+    data("k8s.container.storage_request").publish(label="Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_storage_limit" {
+  name = "Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details"
+
+  program_text = <<-EOF
+    data("k8s.container.storage_limit").publish(label="Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_ephemeralstorage_request" {
+  name = "Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details"
+
+  program_text = <<-EOF
+    data("k8s.container.ephemeralstorage_request").publish(label="Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_ephemeralstorage_limit" {
+  name = "Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details"
+
+  program_text = <<-EOF
+    data("k8s.container.ephemeralstorage_limit").publish(label="Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_restarts" {
+  name = "How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that."
+
+  program_text = <<-EOF
+    data("k8s.container.restarts").publish(label="How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_ready" {
+  name = "Whether a container has passed its readiness probe (0 for no, 1 for yes)"
+
+  program_text = <<-EOF
+    data("k8s.container.ready").publish(label="Whether a container has passed its readiness probe (0 for no, 1 for yes)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_phase" {
+  name = "Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)"
+
+  program_text = <<-EOF
+    data("k8s.pod.phase").publish(label="Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_status_reason" {
+  name = "Current status reason of the pod (1 - Evicted, 2 - NodeAffinity, 3 - NodeLost, 4 - Shutdown, 5 - UnexpectedAdmissionError, 6 - Unknown)"
+
+  program_text = <<-EOF
+    data("k8s.pod.status_reason").publish(label="Current status reason of the pod (1 - Evicted, 2 - NodeAffinity, 3 - NodeLost, 4 - Shutdown, 5 - UnexpectedAdmissionError, 6 - Unknown)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_deployment_desired" {
+  name = "Number of desired pods in this deployment"
+
+  program_text = <<-EOF
+    data("k8s.deployment.desired").publish(label="Number of desired pods in this deployment")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_deployment_available" {
+  name = "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment"
+
+  program_text = <<-EOF
+    data("k8s.deployment.available").publish(label="Total number of available pods (ready for at least minReadySeconds) targeted by this deployment")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_cronjob_active_jobs" {
+  name = "The number of actively running jobs for a cronjob"
+
+  program_text = <<-EOF
+    data("k8s.cronjob.active_jobs").publish(label="The number of actively running jobs for a cronjob")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_daemonset_current_scheduled_nodes" {
+  name = "Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod"
+
+  program_text = <<-EOF
+    data("k8s.daemonset.current_scheduled_nodes").publish(label="Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_daemonset_desired_scheduled_nodes" {
+  name = "Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)"
+
+  program_text = <<-EOF
+    data("k8s.daemonset.desired_scheduled_nodes").publish(label="Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_daemonset_misscheduled_nodes" {
+  name = "Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod"
+
+  program_text = <<-EOF
+    data("k8s.daemonset.misscheduled_nodes").publish(label="Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_daemonset_ready_nodes" {
+  name = "Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready"
+
+  program_text = <<-EOF
+    data("k8s.daemonset.ready_nodes").publish(label="Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_hpa_max_replicas" {
+  name = "Maximum number of replicas to which the autoscaler can scale up."
+
+  program_text = <<-EOF
+    data("k8s.hpa.max_replicas").publish(label="Maximum number of replicas to which the autoscaler can scale up.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_hpa_min_replicas" {
+  name = "Minimum number of replicas to which the autoscaler can scale up."
+
+  program_text = <<-EOF
+    data("k8s.hpa.min_replicas").publish(label="Minimum number of replicas to which the autoscaler can scale up.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_hpa_current_replicas" {
+  name = "Current number of pod replicas managed by this autoscaler."
+
+  program_text = <<-EOF
+    data("k8s.hpa.current_replicas").publish(label="Current number of pod replicas managed by this autoscaler.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_hpa_desired_replicas" {
+  name = "Desired number of pod replicas managed by this autoscaler."
+
+  program_text = <<-EOF
+    data("k8s.hpa.desired_replicas").publish(label="Desired number of pod replicas managed by this autoscaler.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_job_active_pods" {
+  name = "The number of actively running pods for a job"
+
+  program_text = <<-EOF
+    data("k8s.job.active_pods").publish(label="The number of actively running pods for a job")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_job_desired_successful_pods" {
+  name = "The desired number of successfully finished pods the job should be run with"
+
+  program_text = <<-EOF
+    data("k8s.job.desired_successful_pods").publish(label="The desired number of successfully finished pods the job should be run with")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_job_failed_pods" {
+  name = "The number of pods which reached phase Failed for a job"
+
+  program_text = <<-EOF
+    data("k8s.job.failed_pods").publish(label="The number of pods which reached phase Failed for a job")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_job_max_parallel_pods" {
+  name = "The max desired number of pods the job should run at any given time"
+
+  program_text = <<-EOF
+    data("k8s.job.max_parallel_pods").publish(label="The max desired number of pods the job should run at any given time")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_job_successful_pods" {
+  name = "The number of pods which reached phase Succeeded for a job"
+
+  program_text = <<-EOF
+    data("k8s.job.successful_pods").publish(label="The number of pods which reached phase Succeeded for a job")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_namespace_phase" {
+  name = "The current phase of namespaces (1 for active and 0 for terminating)"
+
+  program_text = <<-EOF
+    data("k8s.namespace.phase").publish(label="The current phase of namespaces (1 for active and 0 for terminating)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_replicaset_desired" {
+  name = "Number of desired pods in this replicaset"
+
+  program_text = <<-EOF
+    data("k8s.replicaset.desired").publish(label="Number of desired pods in this replicaset")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_replicaset_available" {
+  name = "Total number of available pods (ready for at least minReadySeconds) targeted by this replicaset"
+
+  program_text = <<-EOF
+    data("k8s.replicaset.available").publish(label="Total number of available pods (ready for at least minReadySeconds) targeted by this replicaset")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_replication_controller_desired" {
+  name = "Number of desired pods in this replication_controller"
+
+  program_text = <<-EOF
+    data("k8s.replication_controller.desired").publish(label="Number of desired pods in this replication_controller")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_replication_controller_available" {
+  name = "Total number of available pods (ready for at least minReadySeconds) targeted by this replication_controller"
+
+  program_text = <<-EOF
+    data("k8s.replication_controller.available").publish(label="Total number of available pods (ready for at least minReadySeconds) targeted by this replication_controller")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_resource_quota_hard_limit" {
+  name = "The upper limit for a particular resource in a specific namespace. Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores"
+
+  program_text = <<-EOF
+    data("k8s.resource_quota.hard_limit").publish(label="The upper limit for a particular resource in a specific namespace. Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_resource_quota_used" {
+  name = "The usage for a particular resource in a specific namespace. Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores"
+
+  program_text = <<-EOF
+    data("k8s.resource_quota.used").publish(label="The usage for a particular resource in a specific namespace. Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_statefulset_desired_pods" {
+  name = "Number of desired pods in the stateful set (the `spec.replicas` field)"
+
+  program_text = <<-EOF
+    data("k8s.statefulset.desired_pods").publish(label="Number of desired pods in the stateful set (the `spec.replicas` field)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_statefulset_ready_pods" {
+  name = "Number of pods created by the stateful set that have the `Ready` condition"
+
+  program_text = <<-EOF
+    data("k8s.statefulset.ready_pods").publish(label="Number of pods created by the stateful set that have the `Ready` condition")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_statefulset_current_pods" {
+  name = "The number of pods created by the StatefulSet controller from the StatefulSet version"
+
+  program_text = <<-EOF
+    data("k8s.statefulset.current_pods").publish(label="The number of pods created by the StatefulSet controller from the StatefulSet version")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_statefulset_updated_pods" {
+  name = "Number of pods created by the StatefulSet controller from the StatefulSet version"
+
+  program_text = <<-EOF
+    data("k8s.statefulset.updated_pods").publish(label="Number of pods created by the StatefulSet controller from the StatefulSet version")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "openshift_clusterquota_limit" {
+  name = "The configured upper limit for a particular resource."
+
+  program_text = <<-EOF
+    data("openshift.clusterquota.limit").publish(label="The configured upper limit for a particular resource.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "openshift_clusterquota_used" {
+  name = "The usage for a particular resource with a configured limit."
+
+  program_text = <<-EOF
+    data("openshift.clusterquota.used").publish(label="The usage for a particular resource with a configured limit.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "openshift_appliedclusterquota_limit" {
+  name = "The upper limit for a particular resource in a specific namespace."
+
+  program_text = <<-EOF
+    data("openshift.appliedclusterquota.limit").publish(label="The upper limit for a particular resource in a specific namespace.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "openshift_appliedclusterquota_used" {
+  name = "The usage for a particular resource in a specific namespace."
+
+  program_text = <<-EOF
+    data("openshift.appliedclusterquota.used").publish(label="The usage for a particular resource in a specific namespace.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_condition" {
+  name = "The condition of a particular Node."
+
+  program_text = <<-EOF
+    data("k8s.node.condition").publish(label="The condition of a particular Node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/kafkametricsreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/kafkametricsreceiver_metadata.yaml.tf
@@ -1,0 +1,172 @@
+
+resource "signalfx_dashboard" "kafkametricsdashboard" {
+  name            = "kafkametrics"
+  dashboard_group = signalfx_dashboard_group.kafkametricsdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.kafka_brokers.id, signalfx_time_chart.kafka_topic_partitions.id, signalfx_time_chart.kafka_partition_current_offset.id, signalfx_time_chart.kafka_partition_oldest_offset.id, signalfx_time_chart.kafka_partition_replicas.id, signalfx_time_chart.kafka_partition_replicas_in_sync.id, signalfx_time_chart.kafka_consumer_group_members.id, signalfx_time_chart.kafka_consumer_group_offset.id, signalfx_time_chart.kafka_consumer_group_offset_sum.id, signalfx_time_chart.kafka_consumer_group_lag.id, signalfx_time_chart.kafka_consumer_group_lag_sum.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "kafkametricsdashboardgroup0" {
+  name        = "kafkametrics generated OTel dashboard group"
+  description = "kafkametrics generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "kafka_brokers" {
+  name = "Number of brokers in the cluster."
+
+  program_text = <<-EOF
+    data("kafka.brokers").publish(label="Number of brokers in the cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "kafka_topic_partitions" {
+  name = "Number of partitions in topic."
+
+  program_text = <<-EOF
+    data("kafka.topic.partitions").publish(label="Number of partitions in topic.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "kafka_partition_current_offset" {
+  name = "Current offset of partition of topic."
+
+  program_text = <<-EOF
+    data("kafka.partition.current_offset").publish(label="Current offset of partition of topic.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "kafka_partition_oldest_offset" {
+  name = "Oldest offset of partition of topic"
+
+  program_text = <<-EOF
+    data("kafka.partition.oldest_offset").publish(label="Oldest offset of partition of topic")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "kafka_partition_replicas" {
+  name = "Number of replicas for partition of topic"
+
+  program_text = <<-EOF
+    data("kafka.partition.replicas").publish(label="Number of replicas for partition of topic")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "kafka_partition_replicas_in_sync" {
+  name = "Number of synchronized replicas of partition"
+
+  program_text = <<-EOF
+    data("kafka.partition.replicas_in_sync").publish(label="Number of synchronized replicas of partition")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "kafka_consumer_group_members" {
+  name = "Count of members in the consumer group"
+
+  program_text = <<-EOF
+    data("kafka.consumer_group.members").publish(label="Count of members in the consumer group")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "kafka_consumer_group_offset" {
+  name = "Current offset of the consumer group at partition of topic"
+
+  program_text = <<-EOF
+    data("kafka.consumer_group.offset").publish(label="Current offset of the consumer group at partition of topic")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "kafka_consumer_group_offset_sum" {
+  name = "Sum of consumer group offset across partitions of topic"
+
+  program_text = <<-EOF
+    data("kafka.consumer_group.offset_sum").publish(label="Sum of consumer group offset across partitions of topic")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "kafka_consumer_group_lag" {
+  name = "Current approximate lag of consumer group at partition of topic"
+
+  program_text = <<-EOF
+    data("kafka.consumer_group.lag").publish(label="Current approximate lag of consumer group at partition of topic")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "kafka_consumer_group_lag_sum" {
+  name = "Current approximate sum of consumer group lag across all partitions of topic"
+
+  program_text = <<-EOF
+    data("kafka.consumer_group.lag_sum").publish(label="Current approximate sum of consumer group lag across all partitions of topic")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/kubeletstatsreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/kubeletstatsreceiver_metadata.yaml.tf
@@ -1,0 +1,760 @@
+
+resource "signalfx_dashboard" "kubeletstatsdashboard" {
+  name            = "kubeletstats"
+  dashboard_group = signalfx_dashboard_group.kubeletstatsdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.k8s_node_cpu_utilization.id, signalfx_time_chart.k8s_node_cpu_time.id, signalfx_time_chart.k8s_node_memory_available.id, signalfx_time_chart.k8s_node_memory_usage.id, signalfx_time_chart.k8s_node_memory_rss.id, signalfx_time_chart.k8s_node_memory_working_set.id, signalfx_time_chart.k8s_node_memory_page_faults.id, signalfx_time_chart.k8s_node_memory_major_page_faults.id, signalfx_time_chart.k8s_node_filesystem_available.id, signalfx_time_chart.k8s_node_filesystem_capacity.id, signalfx_time_chart.k8s_node_filesystem_usage.id, signalfx_time_chart.k8s_node_network_io.id, signalfx_time_chart.k8s_node_network_errors.id, signalfx_time_chart.k8s_node_uptime.id, signalfx_time_chart.k8s_pod_cpu_utilization.id, signalfx_time_chart.k8s_pod_cpu_time.id, signalfx_time_chart.k8s_pod_memory_available.id, signalfx_time_chart.k8s_pod_memory_usage.id, signalfx_time_chart.k8s_pod_cpu_limit_utilization.id, signalfx_time_chart.k8s_pod_cpu_request_utilization.id, signalfx_time_chart.k8s_pod_memory_limit_utilization.id, signalfx_time_chart.k8s_pod_memory_request_utilization.id, signalfx_time_chart.k8s_pod_memory_rss.id, signalfx_time_chart.k8s_pod_memory_working_set.id, signalfx_time_chart.k8s_pod_memory_page_faults.id, signalfx_time_chart.k8s_pod_memory_major_page_faults.id, signalfx_time_chart.k8s_pod_filesystem_available.id, signalfx_time_chart.k8s_pod_filesystem_capacity.id, signalfx_time_chart.k8s_pod_filesystem_usage.id, signalfx_time_chart.k8s_pod_network_io.id, signalfx_time_chart.k8s_pod_network_errors.id, signalfx_time_chart.k8s_pod_uptime.id, signalfx_time_chart.container_cpu_utilization.id, signalfx_time_chart.container_cpu_time.id, signalfx_time_chart.container_memory_available.id, signalfx_time_chart.container_memory_usage.id, signalfx_time_chart.k8s_container_cpu_limit_utilization.id, signalfx_time_chart.k8s_container_cpu_request_utilization.id, signalfx_time_chart.k8s_container_memory_limit_utilization.id, signalfx_time_chart.k8s_container_memory_request_utilization.id, signalfx_time_chart.container_memory_rss.id, signalfx_time_chart.container_memory_working_set.id, signalfx_time_chart.container_memory_page_faults.id, signalfx_time_chart.container_memory_major_page_faults.id, signalfx_time_chart.container_filesystem_available.id, signalfx_time_chart.container_filesystem_capacity.id, signalfx_time_chart.container_filesystem_usage.id, signalfx_time_chart.container_uptime.id, signalfx_time_chart.k8s_volume_available.id, signalfx_time_chart.k8s_volume_capacity.id, signalfx_time_chart.k8s_volume_inodes.id, signalfx_time_chart.k8s_volume_inodes_free.id, signalfx_time_chart.k8s_volume_inodes_used.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "kubeletstatsdashboardgroup0" {
+  name        = "kubeletstats generated OTel dashboard group"
+  description = "kubeletstats generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "k8s_node_cpu_utilization" {
+  name = "Node CPU utilization"
+
+  program_text = <<-EOF
+    data("k8s.node.cpu.utilization").publish(label="Node CPU utilization")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_cpu_time" {
+  name = "Node CPU time"
+
+  program_text = <<-EOF
+    data("k8s.node.cpu.time").publish(label="Node CPU time")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_memory_available" {
+  name = "Node memory available"
+
+  program_text = <<-EOF
+    data("k8s.node.memory.available").publish(label="Node memory available")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_memory_usage" {
+  name = "Node memory usage"
+
+  program_text = <<-EOF
+    data("k8s.node.memory.usage").publish(label="Node memory usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_memory_rss" {
+  name = "Node memory rss"
+
+  program_text = <<-EOF
+    data("k8s.node.memory.rss").publish(label="Node memory rss")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_memory_working_set" {
+  name = "Node memory working_set"
+
+  program_text = <<-EOF
+    data("k8s.node.memory.working_set").publish(label="Node memory working_set")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_memory_page_faults" {
+  name = "Node memory page_faults"
+
+  program_text = <<-EOF
+    data("k8s.node.memory.page_faults").publish(label="Node memory page_faults")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_memory_major_page_faults" {
+  name = "Node memory major_page_faults"
+
+  program_text = <<-EOF
+    data("k8s.node.memory.major_page_faults").publish(label="Node memory major_page_faults")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_filesystem_available" {
+  name = "Node filesystem available"
+
+  program_text = <<-EOF
+    data("k8s.node.filesystem.available").publish(label="Node filesystem available")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_filesystem_capacity" {
+  name = "Node filesystem capacity"
+
+  program_text = <<-EOF
+    data("k8s.node.filesystem.capacity").publish(label="Node filesystem capacity")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_filesystem_usage" {
+  name = "Node filesystem usage"
+
+  program_text = <<-EOF
+    data("k8s.node.filesystem.usage").publish(label="Node filesystem usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_network_io" {
+  name = "Node network IO"
+
+  program_text = <<-EOF
+    data("k8s.node.network.io").publish(label="Node network IO")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_network_errors" {
+  name = "Node network errors"
+
+  program_text = <<-EOF
+    data("k8s.node.network.errors").publish(label="Node network errors")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_node_uptime" {
+  name = "The time since the node started"
+
+  program_text = <<-EOF
+    data("k8s.node.uptime").publish(label="The time since the node started")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_cpu_utilization" {
+  name = "Pod CPU utilization"
+
+  program_text = <<-EOF
+    data("k8s.pod.cpu.utilization").publish(label="Pod CPU utilization")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_cpu_time" {
+  name = "Pod CPU time"
+
+  program_text = <<-EOF
+    data("k8s.pod.cpu.time").publish(label="Pod CPU time")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_memory_available" {
+  name = "Pod memory available"
+
+  program_text = <<-EOF
+    data("k8s.pod.memory.available").publish(label="Pod memory available")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_memory_usage" {
+  name = "Pod memory usage"
+
+  program_text = <<-EOF
+    data("k8s.pod.memory.usage").publish(label="Pod memory usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_cpu_limit_utilization" {
+  name = "Pod cpu utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted."
+
+  program_text = <<-EOF
+    data("k8s.pod.cpu_limit_utilization").publish(label="Pod cpu utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_cpu_request_utilization" {
+  name = "Pod cpu utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted."
+
+  program_text = <<-EOF
+    data("k8s.pod.cpu_request_utilization").publish(label="Pod cpu utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_memory_limit_utilization" {
+  name = "Pod memory utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted."
+
+  program_text = <<-EOF
+    data("k8s.pod.memory_limit_utilization").publish(label="Pod memory utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_memory_request_utilization" {
+  name = "Pod memory utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted."
+
+  program_text = <<-EOF
+    data("k8s.pod.memory_request_utilization").publish(label="Pod memory utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_memory_rss" {
+  name = "Pod memory rss"
+
+  program_text = <<-EOF
+    data("k8s.pod.memory.rss").publish(label="Pod memory rss")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_memory_working_set" {
+  name = "Pod memory working_set"
+
+  program_text = <<-EOF
+    data("k8s.pod.memory.working_set").publish(label="Pod memory working_set")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_memory_page_faults" {
+  name = "Pod memory page_faults"
+
+  program_text = <<-EOF
+    data("k8s.pod.memory.page_faults").publish(label="Pod memory page_faults")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_memory_major_page_faults" {
+  name = "Pod memory major_page_faults"
+
+  program_text = <<-EOF
+    data("k8s.pod.memory.major_page_faults").publish(label="Pod memory major_page_faults")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_filesystem_available" {
+  name = "Pod filesystem available"
+
+  program_text = <<-EOF
+    data("k8s.pod.filesystem.available").publish(label="Pod filesystem available")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_filesystem_capacity" {
+  name = "Pod filesystem capacity"
+
+  program_text = <<-EOF
+    data("k8s.pod.filesystem.capacity").publish(label="Pod filesystem capacity")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_filesystem_usage" {
+  name = "Pod filesystem usage"
+
+  program_text = <<-EOF
+    data("k8s.pod.filesystem.usage").publish(label="Pod filesystem usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_network_io" {
+  name = "Pod network IO"
+
+  program_text = <<-EOF
+    data("k8s.pod.network.io").publish(label="Pod network IO")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_network_errors" {
+  name = "Pod network errors"
+
+  program_text = <<-EOF
+    data("k8s.pod.network.errors").publish(label="Pod network errors")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_pod_uptime" {
+  name = "The time since the pod started"
+
+  program_text = <<-EOF
+    data("k8s.pod.uptime").publish(label="The time since the pod started")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_utilization" {
+  name = "Container CPU utilization"
+
+  program_text = <<-EOF
+    data("container.cpu.utilization").publish(label="Container CPU utilization")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_cpu_time" {
+  name = "Container CPU time"
+
+  program_text = <<-EOF
+    data("container.cpu.time").publish(label="Container CPU time")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_available" {
+  name = "Container memory available"
+
+  program_text = <<-EOF
+    data("container.memory.available").publish(label="Container memory available")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_usage" {
+  name = "Container memory usage"
+
+  program_text = <<-EOF
+    data("container.memory.usage").publish(label="Container memory usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_cpu_limit_utilization" {
+  name = "Container cpu utilization as a ratio of the container's limits"
+
+  program_text = <<-EOF
+    data("k8s.container.cpu_limit_utilization").publish(label="Container cpu utilization as a ratio of the container's limits")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_cpu_request_utilization" {
+  name = "Container cpu utilization as a ratio of the container's requests"
+
+  program_text = <<-EOF
+    data("k8s.container.cpu_request_utilization").publish(label="Container cpu utilization as a ratio of the container's requests")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_memory_limit_utilization" {
+  name = "Container memory utilization as a ratio of the container's limits"
+
+  program_text = <<-EOF
+    data("k8s.container.memory_limit_utilization").publish(label="Container memory utilization as a ratio of the container's limits")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_container_memory_request_utilization" {
+  name = "Container memory utilization as a ratio of the container's requests"
+
+  program_text = <<-EOF
+    data("k8s.container.memory_request_utilization").publish(label="Container memory utilization as a ratio of the container's requests")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_rss" {
+  name = "Container memory rss"
+
+  program_text = <<-EOF
+    data("container.memory.rss").publish(label="Container memory rss")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_working_set" {
+  name = "Container memory working_set"
+
+  program_text = <<-EOF
+    data("container.memory.working_set").publish(label="Container memory working_set")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_page_faults" {
+  name = "Container memory page_faults"
+
+  program_text = <<-EOF
+    data("container.memory.page_faults").publish(label="Container memory page_faults")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_memory_major_page_faults" {
+  name = "Container memory major_page_faults"
+
+  program_text = <<-EOF
+    data("container.memory.major_page_faults").publish(label="Container memory major_page_faults")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_filesystem_available" {
+  name = "Container filesystem available"
+
+  program_text = <<-EOF
+    data("container.filesystem.available").publish(label="Container filesystem available")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_filesystem_capacity" {
+  name = "Container filesystem capacity"
+
+  program_text = <<-EOF
+    data("container.filesystem.capacity").publish(label="Container filesystem capacity")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_filesystem_usage" {
+  name = "Container filesystem usage"
+
+  program_text = <<-EOF
+    data("container.filesystem.usage").publish(label="Container filesystem usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "container_uptime" {
+  name = "The time since the container started"
+
+  program_text = <<-EOF
+    data("container.uptime").publish(label="The time since the container started")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_volume_available" {
+  name = "The number of available bytes in the volume."
+
+  program_text = <<-EOF
+    data("k8s.volume.available").publish(label="The number of available bytes in the volume.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_volume_capacity" {
+  name = "The total capacity in bytes of the volume."
+
+  program_text = <<-EOF
+    data("k8s.volume.capacity").publish(label="The total capacity in bytes of the volume.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_volume_inodes" {
+  name = "The total inodes in the filesystem."
+
+  program_text = <<-EOF
+    data("k8s.volume.inodes").publish(label="The total inodes in the filesystem.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_volume_inodes_free" {
+  name = "The free inodes in the filesystem."
+
+  program_text = <<-EOF
+    data("k8s.volume.inodes.free").publish(label="The free inodes in the filesystem.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "k8s_volume_inodes_used" {
+  name = "The inodes used by the filesystem. This may not equal inodes - free because filesystem may share inodes with other filesystems."
+
+  program_text = <<-EOF
+    data("k8s.volume.inodes.used").publish(label="The inodes used by the filesystem. This may not equal inodes - free because filesystem may share inodes with other filesystems.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/memcachedreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/memcachedreceiver_metadata.yaml.tf
@@ -1,0 +1,172 @@
+
+resource "signalfx_dashboard" "memcacheddashboard" {
+  name            = "memcached"
+  dashboard_group = signalfx_dashboard_group.memcacheddashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.memcached_bytes.id, signalfx_time_chart.memcached_connections_current.id, signalfx_time_chart.memcached_connections_total.id, signalfx_time_chart.memcached_commands.id, signalfx_time_chart.memcached_current_items.id, signalfx_time_chart.memcached_evictions.id, signalfx_time_chart.memcached_network.id, signalfx_time_chart.memcached_operations.id, signalfx_time_chart.memcached_operation_hit_ratio.id, signalfx_time_chart.memcached_cpu_usage.id, signalfx_time_chart.memcached_threads.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "memcacheddashboardgroup0" {
+  name        = "memcached generated OTel dashboard group"
+  description = "memcached generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "memcached_bytes" {
+  name = "Current number of bytes used by this server to store items."
+
+  program_text = <<-EOF
+    data("memcached.bytes").publish(label="Current number of bytes used by this server to store items.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "memcached_connections_current" {
+  name = "The current number of open connections."
+
+  program_text = <<-EOF
+    data("memcached.connections.current").publish(label="The current number of open connections.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "memcached_connections_total" {
+  name = "Total number of connections opened since the server started running."
+
+  program_text = <<-EOF
+    data("memcached.connections.total").publish(label="Total number of connections opened since the server started running.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "memcached_commands" {
+  name = "Commands executed."
+
+  program_text = <<-EOF
+    data("memcached.commands").publish(label="Commands executed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "memcached_current_items" {
+  name = "Number of items currently stored in the cache."
+
+  program_text = <<-EOF
+    data("memcached.current_items").publish(label="Number of items currently stored in the cache.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "memcached_evictions" {
+  name = "Cache item evictions."
+
+  program_text = <<-EOF
+    data("memcached.evictions").publish(label="Cache item evictions.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "memcached_network" {
+  name = "Bytes transferred over the network."
+
+  program_text = <<-EOF
+    data("memcached.network").publish(label="Bytes transferred over the network.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "memcached_operations" {
+  name = "Operation counts."
+
+  program_text = <<-EOF
+    data("memcached.operations").publish(label="Operation counts.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "memcached_operation_hit_ratio" {
+  name = "Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0."
+
+  program_text = <<-EOF
+    data("memcached.operation_hit_ratio").publish(label="Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "memcached_cpu_usage" {
+  name = "Accumulated user and system time."
+
+  program_text = <<-EOF
+    data("memcached.cpu.usage").publish(label="Accumulated user and system time.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "memcached_threads" {
+  name = "Number of threads used by the memcached instance."
+
+  program_text = <<-EOF
+    data("memcached.threads").publish(label="Number of threads used by the memcached instance.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/mongodbatlasreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/mongodbatlasreceiver_metadata.yaml.tf
@@ -1,0 +1,886 @@
+
+resource "signalfx_dashboard" "mongodbatlasdashboard" {
+  name            = "mongodbatlas"
+  dashboard_group = signalfx_dashboard_group.mongodbatlasdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.mongodbatlas_process_asserts.id, signalfx_time_chart.mongodbatlas_process_background_flush.id, signalfx_time_chart.mongodbatlas_process_cache_io.id, signalfx_time_chart.mongodbatlas_process_cache_size.id, signalfx_time_chart.mongodbatlas_process_connections.id, signalfx_time_chart.mongodbatlas_process_cpu_usage_max.id, signalfx_time_chart.mongodbatlas_process_cpu_usage_average.id, signalfx_time_chart.mongodbatlas_process_cpu_children_usage_max.id, signalfx_time_chart.mongodbatlas_process_cpu_children_usage_average.id, signalfx_time_chart.mongodbatlas_process_cpu_children_normalized_usage_max.id, signalfx_time_chart.mongodbatlas_process_cpu_children_normalized_usage_average.id, signalfx_time_chart.mongodbatlas_process_cpu_normalized_usage_max.id, signalfx_time_chart.mongodbatlas_process_cpu_normalized_usage_average.id, signalfx_time_chart.mongodbatlas_process_cursors.id, signalfx_time_chart.mongodbatlas_process_db_storage.id, signalfx_time_chart.mongodbatlas_process_db_document_rate.id, signalfx_time_chart.mongodbatlas_process_global_lock.id, signalfx_time_chart.mongodbatlas_process_index_btree_miss_ratio.id, signalfx_time_chart.mongodbatlas_process_index_counters.id, signalfx_time_chart.mongodbatlas_process_journaling_commits.id, signalfx_time_chart.mongodbatlas_process_journaling_data_files.id, signalfx_time_chart.mongodbatlas_process_journaling_written.id, signalfx_time_chart.mongodbatlas_process_memory_usage.id, signalfx_time_chart.mongodbatlas_process_network_io.id, signalfx_time_chart.mongodbatlas_process_network_requests.id, signalfx_time_chart.mongodbatlas_process_oplog_time.id, signalfx_time_chart.mongodbatlas_process_oplog_rate.id, signalfx_time_chart.mongodbatlas_process_db_operations_rate.id, signalfx_time_chart.mongodbatlas_process_db_operations_time.id, signalfx_time_chart.mongodbatlas_process_page_faults.id, signalfx_time_chart.mongodbatlas_process_db_query_executor_scanned.id, signalfx_time_chart.mongodbatlas_process_db_query_targeting_scanned_per_returned.id, signalfx_time_chart.mongodbatlas_process_restarts.id, signalfx_time_chart.mongodbatlas_system_paging_usage_max.id, signalfx_time_chart.mongodbatlas_system_paging_usage_average.id, signalfx_time_chart.mongodbatlas_system_paging_io_max.id, signalfx_time_chart.mongodbatlas_system_paging_io_average.id, signalfx_time_chart.mongodbatlas_system_cpu_usage_max.id, signalfx_time_chart.mongodbatlas_system_cpu_usage_average.id, signalfx_time_chart.mongodbatlas_system_memory_usage_max.id, signalfx_time_chart.mongodbatlas_system_memory_usage_average.id, signalfx_time_chart.mongodbatlas_system_network_io_max.id, signalfx_time_chart.mongodbatlas_system_network_io_average.id, signalfx_time_chart.mongodbatlas_system_cpu_normalized_usage_max.id, signalfx_time_chart.mongodbatlas_system_cpu_normalized_usage_average.id, signalfx_time_chart.mongodbatlas_process_tickets.id, signalfx_time_chart.mongodbatlas_disk_partition_iops_max.id, signalfx_time_chart.mongodbatlas_disk_partition_iops_average.id, signalfx_time_chart.mongodbatlas_disk_partition_usage_max.id, signalfx_time_chart.mongodbatlas_disk_partition_usage_average.id, signalfx_time_chart.mongodbatlas_disk_partition_utilization_max.id, signalfx_time_chart.mongodbatlas_disk_partition_utilization_average.id, signalfx_time_chart.mongodbatlas_disk_partition_latency_max.id, signalfx_time_chart.mongodbatlas_disk_partition_latency_average.id, signalfx_time_chart.mongodbatlas_disk_partition_space_max.id, signalfx_time_chart.mongodbatlas_disk_partition_space_average.id, signalfx_time_chart.mongodbatlas_db_size.id, signalfx_time_chart.mongodbatlas_db_counts.id, signalfx_time_chart.mongodbatlas_system_fts_memory_usage.id, signalfx_time_chart.mongodbatlas_system_fts_disk_used.id, signalfx_time_chart.mongodbatlas_system_fts_cpu_usage.id, signalfx_time_chart.mongodbatlas_system_fts_cpu_normalized_usage.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "mongodbatlasdashboardgroup0" {
+  name        = "mongodbatlas generated OTel dashboard group"
+  description = "mongodbatlas generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "mongodbatlas_process_asserts" {
+  name = "Number of assertions per second"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.asserts").publish(label="Number of assertions per second")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_background_flush" {
+  name = "Amount of data flushed in the background"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.background_flush").publish(label="Amount of data flushed in the background")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cache_io" {
+  name = "Cache throughput (per second)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cache.io").publish(label="Cache throughput (per second)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cache_size" {
+  name = "Cache sizes"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cache.size").publish(label="Cache sizes")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_connections" {
+  name = "Number of current connections"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.connections").publish(label="Number of current connections")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cpu_usage_max" {
+  name = "CPU Usage (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cpu.usage.max").publish(label="CPU Usage (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cpu_usage_average" {
+  name = "CPU Usage (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cpu.usage.average").publish(label="CPU Usage (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cpu_children_usage_max" {
+  name = "CPU Usage for child processes (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cpu.children.usage.max").publish(label="CPU Usage for child processes (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cpu_children_usage_average" {
+  name = "CPU Usage for child processes (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cpu.children.usage.average").publish(label="CPU Usage for child processes (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cpu_children_normalized_usage_max" {
+  name = "CPU Usage for child processes, normalized to pct"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cpu.children.normalized.usage.max").publish(label="CPU Usage for child processes, normalized to pct")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cpu_children_normalized_usage_average" {
+  name = "CPU Usage for child processes, normalized to pct"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cpu.children.normalized.usage.average").publish(label="CPU Usage for child processes, normalized to pct")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cpu_normalized_usage_max" {
+  name = "CPU Usage, normalized to pct"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cpu.normalized.usage.max").publish(label="CPU Usage, normalized to pct")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cpu_normalized_usage_average" {
+  name = "CPU Usage, normalized to pct"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cpu.normalized.usage.average").publish(label="CPU Usage, normalized to pct")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_cursors" {
+  name = "Number of cursors"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.cursors").publish(label="Number of cursors")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_db_storage" {
+  name = "Storage used by the database"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.db.storage").publish(label="Storage used by the database")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_db_document_rate" {
+  name = "Document access rates"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.db.document.rate").publish(label="Document access rates")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_global_lock" {
+  name = "Number and status of locks"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.global_lock").publish(label="Number and status of locks")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_index_btree_miss_ratio" {
+  name = "Index miss ratio (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.index.btree_miss_ratio").publish(label="Index miss ratio (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_index_counters" {
+  name = "Indexes"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.index.counters").publish(label="Indexes")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_journaling_commits" {
+  name = "Journaling commits"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.journaling.commits").publish(label="Journaling commits")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_journaling_data_files" {
+  name = "Data file sizes"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.journaling.data_files").publish(label="Data file sizes")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_journaling_written" {
+  name = "Journals written"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.journaling.written").publish(label="Journals written")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_memory_usage" {
+  name = "Memory Usage"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.memory.usage").publish(label="Memory Usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_network_io" {
+  name = "Network IO"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.network.io").publish(label="Network IO")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_network_requests" {
+  name = "Network requests"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.network.requests").publish(label="Network requests")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_oplog_time" {
+  name = "Execution time by operation"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.oplog.time").publish(label="Execution time by operation")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_oplog_rate" {
+  name = "Execution rate by operation"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.oplog.rate").publish(label="Execution rate by operation")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_db_operations_rate" {
+  name = "DB Operation Rates"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.db.operations.rate").publish(label="DB Operation Rates")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_db_operations_time" {
+  name = "DB Operation Times"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.db.operations.time").publish(label="DB Operation Times")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_page_faults" {
+  name = "Page faults"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.page_faults").publish(label="Page faults")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_db_query_executor_scanned" {
+  name = "Scanned objects"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.db.query_executor.scanned").publish(label="Scanned objects")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_db_query_targeting_scanned_per_returned" {
+  name = "Scanned objects per returned"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.db.query_targeting.scanned_per_returned").publish(label="Scanned objects per returned")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_restarts" {
+  name = "Restarts in last hour"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.restarts").publish(label="Restarts in last hour")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_paging_usage_max" {
+  name = "Swap usage"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.paging.usage.max").publish(label="Swap usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_paging_usage_average" {
+  name = "Swap usage"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.paging.usage.average").publish(label="Swap usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_paging_io_max" {
+  name = "Swap IO"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.paging.io.max").publish(label="Swap IO")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_paging_io_average" {
+  name = "Swap IO"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.paging.io.average").publish(label="Swap IO")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_cpu_usage_max" {
+  name = "System CPU Usage (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.cpu.usage.max").publish(label="System CPU Usage (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_cpu_usage_average" {
+  name = "System CPU Usage (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.cpu.usage.average").publish(label="System CPU Usage (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_memory_usage_max" {
+  name = "System Memory Usage"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.memory.usage.max").publish(label="System Memory Usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_memory_usage_average" {
+  name = "System Memory Usage"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.memory.usage.average").publish(label="System Memory Usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_network_io_max" {
+  name = "System Network IO"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.network.io.max").publish(label="System Network IO")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_network_io_average" {
+  name = "System Network IO"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.network.io.average").publish(label="System Network IO")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_cpu_normalized_usage_max" {
+  name = "System CPU Normalized to pct"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.cpu.normalized.usage.max").publish(label="System CPU Normalized to pct")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_cpu_normalized_usage_average" {
+  name = "System CPU Normalized to pct"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.cpu.normalized.usage.average").publish(label="System CPU Normalized to pct")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_process_tickets" {
+  name = "Tickets"
+
+  program_text = <<-EOF
+    data("mongodbatlas.process.tickets").publish(label="Tickets")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_disk_partition_iops_max" {
+  name = "Disk partition iops"
+
+  program_text = <<-EOF
+    data("mongodbatlas.disk.partition.iops.max").publish(label="Disk partition iops")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_disk_partition_iops_average" {
+  name = "Disk partition iops"
+
+  program_text = <<-EOF
+    data("mongodbatlas.disk.partition.iops.average").publish(label="Disk partition iops")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_disk_partition_usage_max" {
+  name = "Disk partition usage (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.disk.partition.usage.max").publish(label="Disk partition usage (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_disk_partition_usage_average" {
+  name = "Disk partition usage (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.disk.partition.usage.average").publish(label="Disk partition usage (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_disk_partition_utilization_max" {
+  name = "The maximum percentage of time during which requests are being issued to and serviced by the partition."
+
+  program_text = <<-EOF
+    data("mongodbatlas.disk.partition.utilization.max").publish(label="The maximum percentage of time during which requests are being issued to and serviced by the partition.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_disk_partition_utilization_average" {
+  name = "The percentage of time during which requests are being issued to and serviced by the partition."
+
+  program_text = <<-EOF
+    data("mongodbatlas.disk.partition.utilization.average").publish(label="The percentage of time during which requests are being issued to and serviced by the partition.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_disk_partition_latency_max" {
+  name = "Disk partition latency"
+
+  program_text = <<-EOF
+    data("mongodbatlas.disk.partition.latency.max").publish(label="Disk partition latency")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_disk_partition_latency_average" {
+  name = "Disk partition latency"
+
+  program_text = <<-EOF
+    data("mongodbatlas.disk.partition.latency.average").publish(label="Disk partition latency")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_disk_partition_space_max" {
+  name = "Disk partition space"
+
+  program_text = <<-EOF
+    data("mongodbatlas.disk.partition.space.max").publish(label="Disk partition space")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_disk_partition_space_average" {
+  name = "Disk partition space"
+
+  program_text = <<-EOF
+    data("mongodbatlas.disk.partition.space.average").publish(label="Disk partition space")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_db_size" {
+  name = "Database feature size"
+
+  program_text = <<-EOF
+    data("mongodbatlas.db.size").publish(label="Database feature size")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_db_counts" {
+  name = "Database feature size"
+
+  program_text = <<-EOF
+    data("mongodbatlas.db.counts").publish(label="Database feature size")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_fts_memory_usage" {
+  name = "Full-text search"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.fts.memory.usage").publish(label="Full-text search")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_fts_disk_used" {
+  name = "Full text search disk usage"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.fts.disk.used").publish(label="Full text search disk usage")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_fts_cpu_usage" {
+  name = "Full-text search (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.fts.cpu.usage").publish(label="Full-text search (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodbatlas_system_fts_cpu_normalized_usage" {
+  name = "Full text search disk usage (%)"
+
+  program_text = <<-EOF
+    data("mongodbatlas.system.fts.cpu.normalized.usage").publish(label="Full text search disk usage (%)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/mongodbreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/mongodbreceiver_metadata.yaml.tf
@@ -1,0 +1,438 @@
+
+resource "signalfx_dashboard" "mongodbdashboard" {
+  name            = "mongodb"
+  dashboard_group = signalfx_dashboard_group.mongodbdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.mongodb_cache_operations.id, signalfx_time_chart.mongodb_collection_count.id, signalfx_time_chart.mongodb_data_size.id, signalfx_time_chart.mongodb_connection_count.id, signalfx_time_chart.mongodb_extent_count.id, signalfx_time_chart.mongodb_global_lock_time.id, signalfx_time_chart.mongodb_index_count.id, signalfx_time_chart.mongodb_index_size.id, signalfx_time_chart.mongodb_memory_usage.id, signalfx_time_chart.mongodb_object_count.id, signalfx_time_chart.mongodb_operation_latency_time.id, signalfx_time_chart.mongodb_operation_count.id, signalfx_time_chart.mongodb_operation_repl_count.id, signalfx_time_chart.mongodb_storage_size.id, signalfx_time_chart.mongodb_database_count.id, signalfx_time_chart.mongodb_index_access_count.id, signalfx_time_chart.mongodb_document_operation_count.id, signalfx_time_chart.mongodb_network_io_receive.id, signalfx_time_chart.mongodb_network_io_transmit.id, signalfx_time_chart.mongodb_network_request_count.id, signalfx_time_chart.mongodb_operation_time.id, signalfx_time_chart.mongodb_session_count.id, signalfx_time_chart.mongodb_cursor_count.id, signalfx_time_chart.mongodb_cursor_timeout_count.id, signalfx_time_chart.mongodb_lock_acquire_count.id, signalfx_time_chart.mongodb_lock_acquire_wait_count.id, signalfx_time_chart.mongodb_lock_acquire_time.id, signalfx_time_chart.mongodb_lock_deadlock_count.id, signalfx_time_chart.mongodb_health.id, signalfx_time_chart.mongodb_uptime.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "mongodbdashboardgroup0" {
+  name        = "mongodb generated OTel dashboard group"
+  description = "mongodb generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "mongodb_cache_operations" {
+  name = "The number of cache operations of the instance."
+
+  program_text = <<-EOF
+    data("mongodb.cache.operations").publish(label="The number of cache operations of the instance.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_collection_count" {
+  name = "The number of collections."
+
+  program_text = <<-EOF
+    data("mongodb.collection.count").publish(label="The number of collections.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_data_size" {
+  name = "The size of the collection. Data compression does not affect this value."
+
+  program_text = <<-EOF
+    data("mongodb.data.size").publish(label="The size of the collection. Data compression does not affect this value.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_connection_count" {
+  name = "The number of connections."
+
+  program_text = <<-EOF
+    data("mongodb.connection.count").publish(label="The number of connections.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_extent_count" {
+  name = "The number of extents."
+
+  program_text = <<-EOF
+    data("mongodb.extent.count").publish(label="The number of extents.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_global_lock_time" {
+  name = "The time the global lock has been held."
+
+  program_text = <<-EOF
+    data("mongodb.global_lock.time").publish(label="The time the global lock has been held.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_index_count" {
+  name = "The number of indexes."
+
+  program_text = <<-EOF
+    data("mongodb.index.count").publish(label="The number of indexes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_index_size" {
+  name = "Sum of the space allocated to all indexes in the database, including free index space."
+
+  program_text = <<-EOF
+    data("mongodb.index.size").publish(label="Sum of the space allocated to all indexes in the database, including free index space.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_memory_usage" {
+  name = "The amount of memory used."
+
+  program_text = <<-EOF
+    data("mongodb.memory.usage").publish(label="The amount of memory used.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_object_count" {
+  name = "The number of objects."
+
+  program_text = <<-EOF
+    data("mongodb.object.count").publish(label="The number of objects.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_operation_latency_time" {
+  name = "The latency of operations."
+
+  program_text = <<-EOF
+    data("mongodb.operation.latency.time").publish(label="The latency of operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_operation_count" {
+  name = "The number of operations executed."
+
+  program_text = <<-EOF
+    data("mongodb.operation.count").publish(label="The number of operations executed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_operation_repl_count" {
+  name = "The number of replicated operations executed."
+
+  program_text = <<-EOF
+    data("mongodb.operation.repl.count").publish(label="The number of replicated operations executed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_storage_size" {
+  name = "The total amount of storage allocated to this collection."
+
+  program_text = <<-EOF
+    data("mongodb.storage.size").publish(label="The total amount of storage allocated to this collection.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_database_count" {
+  name = "The number of existing databases."
+
+  program_text = <<-EOF
+    data("mongodb.database.count").publish(label="The number of existing databases.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_index_access_count" {
+  name = "The number of times an index has been accessed."
+
+  program_text = <<-EOF
+    data("mongodb.index.access.count").publish(label="The number of times an index has been accessed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_document_operation_count" {
+  name = "The number of document operations executed."
+
+  program_text = <<-EOF
+    data("mongodb.document.operation.count").publish(label="The number of document operations executed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_network_io_receive" {
+  name = "The number of bytes received."
+
+  program_text = <<-EOF
+    data("mongodb.network.io.receive").publish(label="The number of bytes received.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_network_io_transmit" {
+  name = "The number of by transmitted."
+
+  program_text = <<-EOF
+    data("mongodb.network.io.transmit").publish(label="The number of by transmitted.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_network_request_count" {
+  name = "The number of requests received by the server."
+
+  program_text = <<-EOF
+    data("mongodb.network.request.count").publish(label="The number of requests received by the server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_operation_time" {
+  name = "The total time spent performing operations."
+
+  program_text = <<-EOF
+    data("mongodb.operation.time").publish(label="The total time spent performing operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_session_count" {
+  name = "The total number of active sessions."
+
+  program_text = <<-EOF
+    data("mongodb.session.count").publish(label="The total number of active sessions.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_cursor_count" {
+  name = "The number of open cursors maintained for clients."
+
+  program_text = <<-EOF
+    data("mongodb.cursor.count").publish(label="The number of open cursors maintained for clients.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_cursor_timeout_count" {
+  name = "The number of cursors that have timed out."
+
+  program_text = <<-EOF
+    data("mongodb.cursor.timeout.count").publish(label="The number of cursors that have timed out.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_lock_acquire_count" {
+  name = "Number of times the lock was acquired in the specified mode."
+
+  program_text = <<-EOF
+    data("mongodb.lock.acquire.count").publish(label="Number of times the lock was acquired in the specified mode.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_lock_acquire_wait_count" {
+  name = "Number of times the lock acquisitions encountered waits because the locks were held in a conflicting mode."
+
+  program_text = <<-EOF
+    data("mongodb.lock.acquire.wait_count").publish(label="Number of times the lock acquisitions encountered waits because the locks were held in a conflicting mode.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_lock_acquire_time" {
+  name = "Cumulative wait time for the lock acquisitions."
+
+  program_text = <<-EOF
+    data("mongodb.lock.acquire.time").publish(label="Cumulative wait time for the lock acquisitions.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_lock_deadlock_count" {
+  name = "Number of times the lock acquisitions encountered deadlocks."
+
+  program_text = <<-EOF
+    data("mongodb.lock.deadlock.count").publish(label="Number of times the lock acquisitions encountered deadlocks.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_health" {
+  name = "The health status of the server."
+
+  program_text = <<-EOF
+    data("mongodb.health").publish(label="The health status of the server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mongodb_uptime" {
+  name = "The amount of time that the server has been running."
+
+  program_text = <<-EOF
+    data("mongodb.uptime").publish(label="The amount of time that the server has been running.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/mysqlreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/mysqlreceiver_metadata.yaml.tf
@@ -1,0 +1,620 @@
+
+resource "signalfx_dashboard" "mysqldashboard" {
+  name            = "mysql"
+  dashboard_group = signalfx_dashboard_group.mysqldashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.mysql_buffer_pool_pages.id, signalfx_time_chart.mysql_buffer_pool_data_pages.id, signalfx_time_chart.mysql_buffer_pool_page_flushes.id, signalfx_time_chart.mysql_buffer_pool_operations.id, signalfx_time_chart.mysql_buffer_pool_limit.id, signalfx_time_chart.mysql_buffer_pool_usage.id, signalfx_time_chart.mysql_prepared_statements.id, signalfx_time_chart.mysql_commands.id, signalfx_time_chart.mysql_handlers.id, signalfx_time_chart.mysql_double_writes.id, signalfx_time_chart.mysql_log_operations.id, signalfx_time_chart.mysql_operations.id, signalfx_time_chart.mysql_page_operations.id, signalfx_time_chart.mysql_table_io_wait_count.id, signalfx_time_chart.mysql_table_io_wait_time.id, signalfx_time_chart.mysql_index_io_wait_count.id, signalfx_time_chart.mysql_index_io_wait_time.id, signalfx_time_chart.mysql_row_locks.id, signalfx_time_chart.mysql_row_operations.id, signalfx_time_chart.mysql_locks.id, signalfx_time_chart.mysql_sorts.id, signalfx_time_chart.mysql_threads.id, signalfx_time_chart.mysql_client_network_io.id, signalfx_time_chart.mysql_opened_resources.id, signalfx_time_chart.mysql_uptime.id, signalfx_time_chart.mysql_table_lock_wait_read_count.id, signalfx_time_chart.mysql_table_lock_wait_read_time.id, signalfx_time_chart.mysql_table_lock_wait_write_count.id, signalfx_time_chart.mysql_table_lock_wait_write_time.id, signalfx_time_chart.mysql_connection_count.id, signalfx_time_chart.mysql_connection_errors.id, signalfx_time_chart.mysql_mysqlx_connections.id, signalfx_time_chart.mysql_joins.id, signalfx_time_chart.mysql_tmp_resources.id, signalfx_time_chart.mysql_replica_time_behind_source.id, signalfx_time_chart.mysql_replica_sql_delay.id, signalfx_time_chart.mysql_statement_event_count.id, signalfx_time_chart.mysql_statement_event_wait_time.id, signalfx_time_chart.mysql_mysqlx_worker_threads.id, signalfx_time_chart.mysql_table_open_cache.id, signalfx_time_chart.mysql_query_client_count.id, signalfx_time_chart.mysql_query_count.id, signalfx_time_chart.mysql_query_slow_count.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "mysqldashboardgroup0" {
+  name        = "mysql generated OTel dashboard group"
+  description = "mysql generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "mysql_buffer_pool_pages" {
+  name = "The number of pages in the InnoDB buffer pool."
+
+  program_text = <<-EOF
+    data("mysql.buffer_pool.pages").publish(label="The number of pages in the InnoDB buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_buffer_pool_data_pages" {
+  name = "The number of data pages in the InnoDB buffer pool."
+
+  program_text = <<-EOF
+    data("mysql.buffer_pool.data_pages").publish(label="The number of data pages in the InnoDB buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_buffer_pool_page_flushes" {
+  name = "The number of requests to flush pages from the InnoDB buffer pool."
+
+  program_text = <<-EOF
+    data("mysql.buffer_pool.page_flushes").publish(label="The number of requests to flush pages from the InnoDB buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_buffer_pool_operations" {
+  name = "The number of operations on the InnoDB buffer pool."
+
+  program_text = <<-EOF
+    data("mysql.buffer_pool.operations").publish(label="The number of operations on the InnoDB buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_buffer_pool_limit" {
+  name = "The configured size of the InnoDB buffer pool."
+
+  program_text = <<-EOF
+    data("mysql.buffer_pool.limit").publish(label="The configured size of the InnoDB buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_buffer_pool_usage" {
+  name = "The number of bytes in the InnoDB buffer pool."
+
+  program_text = <<-EOF
+    data("mysql.buffer_pool.usage").publish(label="The number of bytes in the InnoDB buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_prepared_statements" {
+  name = "The number of times each type of prepared statement command has been issued."
+
+  program_text = <<-EOF
+    data("mysql.prepared_statements").publish(label="The number of times each type of prepared statement command has been issued.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_commands" {
+  name = "The number of times each type of command has been executed."
+
+  program_text = <<-EOF
+    data("mysql.commands").publish(label="The number of times each type of command has been executed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_handlers" {
+  name = "The number of requests to various MySQL handlers."
+
+  program_text = <<-EOF
+    data("mysql.handlers").publish(label="The number of requests to various MySQL handlers.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_double_writes" {
+  name = "The number of writes to the InnoDB doublewrite buffer."
+
+  program_text = <<-EOF
+    data("mysql.double_writes").publish(label="The number of writes to the InnoDB doublewrite buffer.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_log_operations" {
+  name = "The number of InnoDB log operations."
+
+  program_text = <<-EOF
+    data("mysql.log_operations").publish(label="The number of InnoDB log operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_operations" {
+  name = "The number of InnoDB operations."
+
+  program_text = <<-EOF
+    data("mysql.operations").publish(label="The number of InnoDB operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_page_operations" {
+  name = "The number of InnoDB page operations."
+
+  program_text = <<-EOF
+    data("mysql.page_operations").publish(label="The number of InnoDB page operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_table_io_wait_count" {
+  name = "The total count of I/O wait events for a table."
+
+  program_text = <<-EOF
+    data("mysql.table.io.wait.count").publish(label="The total count of I/O wait events for a table.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_table_io_wait_time" {
+  name = "The total time of I/O wait events for a table."
+
+  program_text = <<-EOF
+    data("mysql.table.io.wait.time").publish(label="The total time of I/O wait events for a table.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_index_io_wait_count" {
+  name = "The total count of I/O wait events for an index."
+
+  program_text = <<-EOF
+    data("mysql.index.io.wait.count").publish(label="The total count of I/O wait events for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_index_io_wait_time" {
+  name = "The total time of I/O wait events for an index."
+
+  program_text = <<-EOF
+    data("mysql.index.io.wait.time").publish(label="The total time of I/O wait events for an index.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_row_locks" {
+  name = "The number of InnoDB row locks."
+
+  program_text = <<-EOF
+    data("mysql.row_locks").publish(label="The number of InnoDB row locks.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_row_operations" {
+  name = "The number of InnoDB row operations."
+
+  program_text = <<-EOF
+    data("mysql.row_operations").publish(label="The number of InnoDB row operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_locks" {
+  name = "The number of MySQL locks."
+
+  program_text = <<-EOF
+    data("mysql.locks").publish(label="The number of MySQL locks.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_sorts" {
+  name = "The number of MySQL sorts."
+
+  program_text = <<-EOF
+    data("mysql.sorts").publish(label="The number of MySQL sorts.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_threads" {
+  name = "The state of MySQL threads."
+
+  program_text = <<-EOF
+    data("mysql.threads").publish(label="The state of MySQL threads.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_client_network_io" {
+  name = "The number of transmitted bytes between server and clients."
+
+  program_text = <<-EOF
+    data("mysql.client.network.io").publish(label="The number of transmitted bytes between server and clients.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_opened_resources" {
+  name = "The number of opened resources."
+
+  program_text = <<-EOF
+    data("mysql.opened_resources").publish(label="The number of opened resources.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_uptime" {
+  name = "The number of seconds that the server has been up."
+
+  program_text = <<-EOF
+    data("mysql.uptime").publish(label="The number of seconds that the server has been up.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_table_lock_wait_read_count" {
+  name = "The total table lock wait read events."
+
+  program_text = <<-EOF
+    data("mysql.table.lock_wait.read.count").publish(label="The total table lock wait read events.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_table_lock_wait_read_time" {
+  name = "The total table lock wait read events times."
+
+  program_text = <<-EOF
+    data("mysql.table.lock_wait.read.time").publish(label="The total table lock wait read events times.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_table_lock_wait_write_count" {
+  name = "The total table lock wait write events."
+
+  program_text = <<-EOF
+    data("mysql.table.lock_wait.write.count").publish(label="The total table lock wait write events.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_table_lock_wait_write_time" {
+  name = "The total table lock wait write events times."
+
+  program_text = <<-EOF
+    data("mysql.table.lock_wait.write.time").publish(label="The total table lock wait write events times.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_connection_count" {
+  name = "The number of connection attempts (successful or not) to the MySQL server."
+
+  program_text = <<-EOF
+    data("mysql.connection.count").publish(label="The number of connection attempts (successful or not) to the MySQL server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_connection_errors" {
+  name = "Errors that occur during the client connection process."
+
+  program_text = <<-EOF
+    data("mysql.connection.errors").publish(label="Errors that occur during the client connection process.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_mysqlx_connections" {
+  name = "The number of mysqlx connections."
+
+  program_text = <<-EOF
+    data("mysql.mysqlx_connections").publish(label="The number of mysqlx connections.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_joins" {
+  name = "The number of joins that perform table scans."
+
+  program_text = <<-EOF
+    data("mysql.joins").publish(label="The number of joins that perform table scans.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_tmp_resources" {
+  name = "The number of created temporary resources."
+
+  program_text = <<-EOF
+    data("mysql.tmp_resources").publish(label="The number of created temporary resources.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_replica_time_behind_source" {
+  name = "This field is an indication of how “late” the replica is."
+
+  program_text = <<-EOF
+    data("mysql.replica.time_behind_source").publish(label="This field is an indication of how “late” the replica is.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_replica_sql_delay" {
+  name = "The number of seconds that the replica must lag the source."
+
+  program_text = <<-EOF
+    data("mysql.replica.sql_delay").publish(label="The number of seconds that the replica must lag the source.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_statement_event_count" {
+  name = "Summary of current and recent statement events."
+
+  program_text = <<-EOF
+    data("mysql.statement_event.count").publish(label="Summary of current and recent statement events.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_statement_event_wait_time" {
+  name = "The total wait time of the summarized timed events."
+
+  program_text = <<-EOF
+    data("mysql.statement_event.wait.time").publish(label="The total wait time of the summarized timed events.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_mysqlx_worker_threads" {
+  name = "The number of worker threads available."
+
+  program_text = <<-EOF
+    data("mysql.mysqlx_worker_threads").publish(label="The number of worker threads available.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_table_open_cache" {
+  name = "The number of hits, misses or overflows for open tables cache lookups."
+
+  program_text = <<-EOF
+    data("mysql.table_open_cache").publish(label="The number of hits, misses or overflows for open tables cache lookups.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_query_client_count" {
+  name = "The number of statements executed by the server. This includes only statements sent to the server by clients."
+
+  program_text = <<-EOF
+    data("mysql.query.client.count").publish(label="The number of statements executed by the server. This includes only statements sent to the server by clients.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_query_count" {
+  name = "The number of statements executed by the server."
+
+  program_text = <<-EOF
+    data("mysql.query.count").publish(label="The number of statements executed by the server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "mysql_query_slow_count" {
+  name = "The number of slow queries."
+
+  program_text = <<-EOF
+    data("mysql.query.slow.count").publish(label="The number of slow queries.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/nginxreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/nginxreceiver_metadata.yaml.tf
@@ -1,0 +1,74 @@
+
+resource "signalfx_dashboard" "nginxdashboard" {
+  name            = "nginx"
+  dashboard_group = signalfx_dashboard_group.nginxdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.nginx_requests.id, signalfx_time_chart.nginx_connections_accepted.id, signalfx_time_chart.nginx_connections_handled.id, signalfx_time_chart.nginx_connections_current.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "nginxdashboardgroup0" {
+  name        = "nginx generated OTel dashboard group"
+  description = "nginx generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "nginx_requests" {
+  name = "Total number of requests made to the server since it started"
+
+  program_text = <<-EOF
+    data("nginx.requests").publish(label="Total number of requests made to the server since it started")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "nginx_connections_accepted" {
+  name = "The total number of accepted client connections"
+
+  program_text = <<-EOF
+    data("nginx.connections_accepted").publish(label="The total number of accepted client connections")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "nginx_connections_handled" {
+  name = "The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit)."
+
+  program_text = <<-EOF
+    data("nginx.connections_handled").publish(label="The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "nginx_connections_current" {
+  name = "The current number of nginx connections by state"
+
+  program_text = <<-EOF
+    data("nginx.connections_current").publish(label="The current number of nginx connections by state")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/nsxtreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/nsxtreceiver_metadata.yaml.tf
@@ -1,0 +1,116 @@
+
+resource "signalfx_dashboard" "nsxtdashboard" {
+  name            = "nsxt"
+  dashboard_group = signalfx_dashboard_group.nsxtdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.nsxt_node_network_io.id, signalfx_time_chart.nsxt_node_network_packet_count.id, signalfx_time_chart.nsxt_node_cpu_utilization.id, signalfx_time_chart.nsxt_node_filesystem_utilization.id, signalfx_time_chart.nsxt_node_filesystem_usage.id, signalfx_time_chart.nsxt_node_memory_usage.id, signalfx_time_chart.nsxt_node_memory_cache_usage.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "nsxtdashboardgroup0" {
+  name        = "nsxt generated OTel dashboard group"
+  description = "nsxt generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "nsxt_node_network_io" {
+  name = "The number of bytes which have flowed through the network interface."
+
+  program_text = <<-EOF
+    data("nsxt.node.network.io").publish(label="The number of bytes which have flowed through the network interface.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "nsxt_node_network_packet_count" {
+  name = "The number of packets which have flowed through the network interface on the node."
+
+  program_text = <<-EOF
+    data("nsxt.node.network.packet.count").publish(label="The number of packets which have flowed through the network interface on the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "nsxt_node_cpu_utilization" {
+  name = "The average amount of CPU being used by the node."
+
+  program_text = <<-EOF
+    data("nsxt.node.cpu.utilization").publish(label="The average amount of CPU being used by the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "nsxt_node_filesystem_utilization" {
+  name = "The percentage of storage space utilized."
+
+  program_text = <<-EOF
+    data("nsxt.node.filesystem.utilization").publish(label="The percentage of storage space utilized.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "nsxt_node_filesystem_usage" {
+  name = "The amount of storage space used by the node."
+
+  program_text = <<-EOF
+    data("nsxt.node.filesystem.usage").publish(label="The amount of storage space used by the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "nsxt_node_memory_usage" {
+  name = "The memory usage of the node."
+
+  program_text = <<-EOF
+    data("nsxt.node.memory.usage").publish(label="The memory usage of the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "nsxt_node_memory_cache_usage" {
+  name = "The size of the node's memory cache."
+
+  program_text = <<-EOF
+    data("nsxt.node.memory.cache.usage").publish(label="The size of the node's memory cache.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/oracledbreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/oracledbreceiver_metadata.yaml.tf
@@ -1,0 +1,396 @@
+
+resource "signalfx_dashboard" "oracledbdashboard" {
+  name            = "oracledb"
+  dashboard_group = signalfx_dashboard_group.oracledbdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.oracledb_cpu_time.id, signalfx_time_chart.oracledb_enqueue_deadlocks.id, signalfx_time_chart.oracledb_exchange_deadlocks.id, signalfx_time_chart.oracledb_executions.id, signalfx_time_chart.oracledb_logical_reads.id, signalfx_time_chart.oracledb_hard_parses.id, signalfx_time_chart.oracledb_parse_calls.id, signalfx_time_chart.oracledb_pga_memory.id, signalfx_time_chart.oracledb_physical_reads.id, signalfx_time_chart.oracledb_user_commits.id, signalfx_time_chart.oracledb_user_rollbacks.id, signalfx_time_chart.oracledb_sessions_usage.id, signalfx_time_chart.oracledb_processes_usage.id, signalfx_time_chart.oracledb_processes_limit.id, signalfx_time_chart.oracledb_sessions_limit.id, signalfx_time_chart.oracledb_enqueue_locks_usage.id, signalfx_time_chart.oracledb_enqueue_locks_limit.id, signalfx_time_chart.oracledb_dml_locks_usage.id, signalfx_time_chart.oracledb_dml_locks_limit.id, signalfx_time_chart.oracledb_enqueue_resources_usage.id, signalfx_time_chart.oracledb_enqueue_resources_limit.id, signalfx_time_chart.oracledb_transactions_usage.id, signalfx_time_chart.oracledb_transactions_limit.id, signalfx_time_chart.oracledb_tablespace_size_limit.id, signalfx_time_chart.oracledb_tablespace_size_usage.id, signalfx_time_chart.oracledb_db_block_gets.id, signalfx_time_chart.oracledb_consistent_gets.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "oracledbdashboardgroup0" {
+  name        = "oracledb generated OTel dashboard group"
+  description = "oracledb generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "oracledb_cpu_time" {
+  name = "Cumulative CPU time, in seconds"
+
+  program_text = <<-EOF
+    data("oracledb.cpu_time").publish(label="Cumulative CPU time, in seconds")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_enqueue_deadlocks" {
+  name = "Total number of deadlocks between table or row locks in different sessions."
+
+  program_text = <<-EOF
+    data("oracledb.enqueue_deadlocks").publish(label="Total number of deadlocks between table or row locks in different sessions.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_exchange_deadlocks" {
+  name = "Number of times that a process detected a potential deadlock when exchanging two buffers and raised an internal, restartable error. Index scans are the only operations that perform exchanges."
+
+  program_text = <<-EOF
+    data("oracledb.exchange_deadlocks").publish(label="Number of times that a process detected a potential deadlock when exchanging two buffers and raised an internal, restartable error. Index scans are the only operations that perform exchanges.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_executions" {
+  name = "Total number of calls (user and recursive) that executed SQL statements"
+
+  program_text = <<-EOF
+    data("oracledb.executions").publish(label="Total number of calls (user and recursive) that executed SQL statements")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_logical_reads" {
+  name = "Number of logical reads"
+
+  program_text = <<-EOF
+    data("oracledb.logical_reads").publish(label="Number of logical reads")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_hard_parses" {
+  name = "Number of hard parses"
+
+  program_text = <<-EOF
+    data("oracledb.hard_parses").publish(label="Number of hard parses")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_parse_calls" {
+  name = "Total number of parse calls."
+
+  program_text = <<-EOF
+    data("oracledb.parse_calls").publish(label="Total number of parse calls.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_pga_memory" {
+  name = "Session PGA (Program Global Area) memory"
+
+  program_text = <<-EOF
+    data("oracledb.pga_memory").publish(label="Session PGA (Program Global Area) memory")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_physical_reads" {
+  name = "Number of physical reads"
+
+  program_text = <<-EOF
+    data("oracledb.physical_reads").publish(label="Number of physical reads")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_user_commits" {
+  name = "Number of user commits. When a user commits a transaction, the redo generated that reflects the changes made to database blocks must be written to disk. Commits often represent the closest thing to a user transaction rate."
+
+  program_text = <<-EOF
+    data("oracledb.user_commits").publish(label="Number of user commits. When a user commits a transaction, the redo generated that reflects the changes made to database blocks must be written to disk. Commits often represent the closest thing to a user transaction rate.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_user_rollbacks" {
+  name = "Number of times users manually issue the ROLLBACK statement or an error occurs during a user's transactions"
+
+  program_text = <<-EOF
+    data("oracledb.user_rollbacks").publish(label="Number of times users manually issue the ROLLBACK statement or an error occurs during a user's transactions")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_sessions_usage" {
+  name = "Count of active sessions."
+
+  program_text = <<-EOF
+    data("oracledb.sessions.usage").publish(label="Count of active sessions.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_processes_usage" {
+  name = "Current count of active processes."
+
+  program_text = <<-EOF
+    data("oracledb.processes.usage").publish(label="Current count of active processes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_processes_limit" {
+  name = "Maximum limit of active processes, -1 if unlimited."
+
+  program_text = <<-EOF
+    data("oracledb.processes.limit").publish(label="Maximum limit of active processes, -1 if unlimited.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_sessions_limit" {
+  name = "Maximum limit of active sessions, -1 if unlimited."
+
+  program_text = <<-EOF
+    data("oracledb.sessions.limit").publish(label="Maximum limit of active sessions, -1 if unlimited.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_enqueue_locks_usage" {
+  name = "Current count of active enqueue locks."
+
+  program_text = <<-EOF
+    data("oracledb.enqueue_locks.usage").publish(label="Current count of active enqueue locks.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_enqueue_locks_limit" {
+  name = "Maximum limit of active enqueue locks, -1 if unlimited."
+
+  program_text = <<-EOF
+    data("oracledb.enqueue_locks.limit").publish(label="Maximum limit of active enqueue locks, -1 if unlimited.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_dml_locks_usage" {
+  name = "Current count of active DML (Data Manipulation Language) locks."
+
+  program_text = <<-EOF
+    data("oracledb.dml_locks.usage").publish(label="Current count of active DML (Data Manipulation Language) locks.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_dml_locks_limit" {
+  name = "Maximum limit of active DML (Data Manipulation Language) locks, -1 if unlimited."
+
+  program_text = <<-EOF
+    data("oracledb.dml_locks.limit").publish(label="Maximum limit of active DML (Data Manipulation Language) locks, -1 if unlimited.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_enqueue_resources_usage" {
+  name = "Current count of active enqueue resources."
+
+  program_text = <<-EOF
+    data("oracledb.enqueue_resources.usage").publish(label="Current count of active enqueue resources.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_enqueue_resources_limit" {
+  name = "Maximum limit of active enqueue resources, -1 if unlimited."
+
+  program_text = <<-EOF
+    data("oracledb.enqueue_resources.limit").publish(label="Maximum limit of active enqueue resources, -1 if unlimited.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_transactions_usage" {
+  name = "Current count of active transactions."
+
+  program_text = <<-EOF
+    data("oracledb.transactions.usage").publish(label="Current count of active transactions.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_transactions_limit" {
+  name = "Maximum limit of active transactions, -1 if unlimited."
+
+  program_text = <<-EOF
+    data("oracledb.transactions.limit").publish(label="Maximum limit of active transactions, -1 if unlimited.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_tablespace_size_limit" {
+  name = "Maximum size of tablespace in bytes, -1 if unlimited."
+
+  program_text = <<-EOF
+    data("oracledb.tablespace_size.limit").publish(label="Maximum size of tablespace in bytes, -1 if unlimited.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_tablespace_size_usage" {
+  name = "Used tablespace in bytes."
+
+  program_text = <<-EOF
+    data("oracledb.tablespace_size.usage").publish(label="Used tablespace in bytes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_db_block_gets" {
+  name = "Number of times a current block was requested from the buffer cache."
+
+  program_text = <<-EOF
+    data("oracledb.db_block_gets").publish(label="Number of times a current block was requested from the buffer cache.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "oracledb_consistent_gets" {
+  name = "Number of times a consistent read was requested for a block from the buffer cache."
+
+  program_text = <<-EOF
+    data("oracledb.consistent_gets").publish(label="Number of times a consistent read was requested for a block from the buffer cache.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/postgresqlreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/postgresqlreceiver_metadata.yaml.tf
@@ -1,0 +1,396 @@
+
+resource "signalfx_dashboard" "postgresqldashboard" {
+  name            = "postgresql"
+  dashboard_group = signalfx_dashboard_group.postgresqldashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.postgresql_bgwriter_buffers_allocated.id, signalfx_time_chart.postgresql_bgwriter_buffers_writes.id, signalfx_time_chart.postgresql_bgwriter_checkpoint_count.id, signalfx_time_chart.postgresql_bgwriter_duration.id, signalfx_time_chart.postgresql_bgwriter_maxwritten.id, signalfx_time_chart.postgresql_blocks_read.id, signalfx_time_chart.postgresql_commits.id, signalfx_time_chart.postgresql_database_count.id, signalfx_time_chart.postgresql_database_locks.id, signalfx_time_chart.postgresql_db_size.id, signalfx_time_chart.postgresql_backends.id, signalfx_time_chart.postgresql_connection_max.id, signalfx_time_chart.postgresql_rows.id, signalfx_time_chart.postgresql_index_scans.id, signalfx_time_chart.postgresql_index_size.id, signalfx_time_chart.postgresql_operations.id, signalfx_time_chart.postgresql_replication_data_delay.id, signalfx_time_chart.postgresql_rollbacks.id, signalfx_time_chart.postgresql_deadlocks.id, signalfx_time_chart.postgresql_sequential_scans.id, signalfx_time_chart.postgresql_table_count.id, signalfx_time_chart.postgresql_table_size.id, signalfx_time_chart.postgresql_table_vacuum_count.id, signalfx_time_chart.postgresql_temp_files.id, signalfx_time_chart.postgresql_wal_age.id, signalfx_time_chart.postgresql_wal_lag.id, signalfx_time_chart.postgresql_wal_delay.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "postgresqldashboardgroup0" {
+  name        = "postgresql generated OTel dashboard group"
+  description = "postgresql generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "postgresql_bgwriter_buffers_allocated" {
+  name = "Number of buffers allocated."
+
+  program_text = <<-EOF
+    data("postgresql.bgwriter.buffers.allocated").publish(label="Number of buffers allocated.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_bgwriter_buffers_writes" {
+  name = "Number of buffers written."
+
+  program_text = <<-EOF
+    data("postgresql.bgwriter.buffers.writes").publish(label="Number of buffers written.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_bgwriter_checkpoint_count" {
+  name = "The number of checkpoints performed."
+
+  program_text = <<-EOF
+    data("postgresql.bgwriter.checkpoint.count").publish(label="The number of checkpoints performed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_bgwriter_duration" {
+  name = "Total time spent writing and syncing files to disk by checkpoints."
+
+  program_text = <<-EOF
+    data("postgresql.bgwriter.duration").publish(label="Total time spent writing and syncing files to disk by checkpoints.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_bgwriter_maxwritten" {
+  name = "Number of times the background writer stopped a cleaning scan because it had written too many buffers."
+
+  program_text = <<-EOF
+    data("postgresql.bgwriter.maxwritten").publish(label="Number of times the background writer stopped a cleaning scan because it had written too many buffers.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_blocks_read" {
+  name = "The number of blocks read."
+
+  program_text = <<-EOF
+    data("postgresql.blocks_read").publish(label="The number of blocks read.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_commits" {
+  name = "The number of commits."
+
+  program_text = <<-EOF
+    data("postgresql.commits").publish(label="The number of commits.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_database_count" {
+  name = "Number of user databases."
+
+  program_text = <<-EOF
+    data("postgresql.database.count").publish(label="Number of user databases.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_database_locks" {
+  name = "The number of database locks."
+
+  program_text = <<-EOF
+    data("postgresql.database.locks").publish(label="The number of database locks.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_db_size" {
+  name = "The database disk usage."
+
+  program_text = <<-EOF
+    data("postgresql.db_size").publish(label="The database disk usage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_backends" {
+  name = "The number of backends."
+
+  program_text = <<-EOF
+    data("postgresql.backends").publish(label="The number of backends.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_connection_max" {
+  name = "Configured maximum number of client connections allowed"
+
+  program_text = <<-EOF
+    data("postgresql.connection.max").publish(label="Configured maximum number of client connections allowed")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_rows" {
+  name = "The number of rows in the database."
+
+  program_text = <<-EOF
+    data("postgresql.rows").publish(label="The number of rows in the database.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_index_scans" {
+  name = "The number of index scans on a table."
+
+  program_text = <<-EOF
+    data("postgresql.index.scans").publish(label="The number of index scans on a table.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_index_size" {
+  name = "The size of the index on disk."
+
+  program_text = <<-EOF
+    data("postgresql.index.size").publish(label="The size of the index on disk.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_operations" {
+  name = "The number of db row operations."
+
+  program_text = <<-EOF
+    data("postgresql.operations").publish(label="The number of db row operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_replication_data_delay" {
+  name = "The amount of data delayed in replication."
+
+  program_text = <<-EOF
+    data("postgresql.replication.data_delay").publish(label="The amount of data delayed in replication.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_rollbacks" {
+  name = "The number of rollbacks."
+
+  program_text = <<-EOF
+    data("postgresql.rollbacks").publish(label="The number of rollbacks.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_deadlocks" {
+  name = "The number of deadlocks."
+
+  program_text = <<-EOF
+    data("postgresql.deadlocks").publish(label="The number of deadlocks.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_sequential_scans" {
+  name = "The number of sequential scans."
+
+  program_text = <<-EOF
+    data("postgresql.sequential_scans").publish(label="The number of sequential scans.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_table_count" {
+  name = "Number of user tables in a database."
+
+  program_text = <<-EOF
+    data("postgresql.table.count").publish(label="Number of user tables in a database.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_table_size" {
+  name = "Disk space used by a table."
+
+  program_text = <<-EOF
+    data("postgresql.table.size").publish(label="Disk space used by a table.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_table_vacuum_count" {
+  name = "Number of times a table has manually been vacuumed."
+
+  program_text = <<-EOF
+    data("postgresql.table.vacuum.count").publish(label="Number of times a table has manually been vacuumed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_temp_files" {
+  name = "The number of temp files."
+
+  program_text = <<-EOF
+    data("postgresql.temp_files").publish(label="The number of temp files.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_wal_age" {
+  name = "Age of the oldest WAL file."
+
+  program_text = <<-EOF
+    data("postgresql.wal.age").publish(label="Age of the oldest WAL file.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_wal_lag" {
+  name = "Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it."
+
+  program_text = <<-EOF
+    data("postgresql.wal.lag").publish(label="Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "postgresql_wal_delay" {
+  name = "Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it."
+
+  program_text = <<-EOF
+    data("postgresql.wal.delay").publish(label="Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/rabbitmqreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/rabbitmqreceiver_metadata.yaml.tf
@@ -1,0 +1,102 @@
+
+resource "signalfx_dashboard" "rabbitmqdashboard" {
+  name            = "rabbitmq"
+  dashboard_group = signalfx_dashboard_group.rabbitmqdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.rabbitmq_consumer_count.id, signalfx_time_chart.rabbitmq_message_delivered.id, signalfx_time_chart.rabbitmq_message_published.id, signalfx_time_chart.rabbitmq_message_acknowledged.id, signalfx_time_chart.rabbitmq_message_dropped.id, signalfx_time_chart.rabbitmq_message_current.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "rabbitmqdashboardgroup0" {
+  name        = "rabbitmq generated OTel dashboard group"
+  description = "rabbitmq generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "rabbitmq_consumer_count" {
+  name = "The number of consumers currently reading from the queue."
+
+  program_text = <<-EOF
+    data("rabbitmq.consumer.count").publish(label="The number of consumers currently reading from the queue.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "rabbitmq_message_delivered" {
+  name = "The number of messages delivered to consumers."
+
+  program_text = <<-EOF
+    data("rabbitmq.message.delivered").publish(label="The number of messages delivered to consumers.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "rabbitmq_message_published" {
+  name = "The number of messages published to a queue."
+
+  program_text = <<-EOF
+    data("rabbitmq.message.published").publish(label="The number of messages published to a queue.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "rabbitmq_message_acknowledged" {
+  name = "The number of messages acknowledged by consumers."
+
+  program_text = <<-EOF
+    data("rabbitmq.message.acknowledged").publish(label="The number of messages acknowledged by consumers.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "rabbitmq_message_dropped" {
+  name = "The number of messages dropped as unroutable."
+
+  program_text = <<-EOF
+    data("rabbitmq.message.dropped").publish(label="The number of messages dropped as unroutable.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "rabbitmq_message_current" {
+  name = "The total number of messages currently in the queue."
+
+  program_text = <<-EOF
+    data("rabbitmq.message.current").publish(label="The total number of messages currently in the queue.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/redisreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/redisreceiver_metadata.yaml.tf
@@ -1,0 +1,494 @@
+
+resource "signalfx_dashboard" "redisdashboard" {
+  name            = "redis"
+  dashboard_group = signalfx_dashboard_group.redisdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.redis_maxmemory.id, signalfx_time_chart.redis_role.id, signalfx_time_chart.redis_cmd_calls.id, signalfx_time_chart.redis_cmd_usec.id, signalfx_time_chart.redis_cmd_latency.id, signalfx_time_chart.redis_uptime.id, signalfx_time_chart.redis_cpu_time.id, signalfx_time_chart.redis_clients_connected.id, signalfx_time_chart.redis_clients_max_input_buffer.id, signalfx_time_chart.redis_clients_max_output_buffer.id, signalfx_time_chart.redis_clients_blocked.id, signalfx_time_chart.redis_keys_expired.id, signalfx_time_chart.redis_keys_evicted.id, signalfx_time_chart.redis_connections_received.id, signalfx_time_chart.redis_connections_rejected.id, signalfx_time_chart.redis_memory_used.id, signalfx_time_chart.redis_memory_peak.id, signalfx_time_chart.redis_memory_rss.id, signalfx_time_chart.redis_memory_lua.id, signalfx_time_chart.redis_memory_fragmentation_ratio.id, signalfx_time_chart.redis_rdb_changes_since_last_save.id, signalfx_time_chart.redis_commands.id, signalfx_time_chart.redis_commands_processed.id, signalfx_time_chart.redis_net_input.id, signalfx_time_chart.redis_net_output.id, signalfx_time_chart.redis_keyspace_hits.id, signalfx_time_chart.redis_keyspace_misses.id, signalfx_time_chart.redis_latest_fork.id, signalfx_time_chart.redis_slaves_connected.id, signalfx_time_chart.redis_replication_backlog_first_byte_offset.id, signalfx_time_chart.redis_replication_offset.id, signalfx_time_chart.redis_db_keys.id, signalfx_time_chart.redis_db_expires.id, signalfx_time_chart.redis_db_avg_ttl.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "redisdashboardgroup0" {
+  name        = "redis generated OTel dashboard group"
+  description = "redis generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "redis_maxmemory" {
+  name = "The value of the maxmemory configuration directive"
+
+  program_text = <<-EOF
+    data("redis.maxmemory").publish(label="The value of the maxmemory configuration directive")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_role" {
+  name = "Redis node's role"
+
+  program_text = <<-EOF
+    data("redis.role").publish(label="Redis node's role")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_cmd_calls" {
+  name = "Total number of calls for a command"
+
+  program_text = <<-EOF
+    data("redis.cmd.calls").publish(label="Total number of calls for a command")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_cmd_usec" {
+  name = "Total time for all executions of this command"
+
+  program_text = <<-EOF
+    data("redis.cmd.usec").publish(label="Total time for all executions of this command")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_cmd_latency" {
+  name = "Command execution latency"
+
+  program_text = <<-EOF
+    data("redis.cmd.latency").publish(label="Command execution latency")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_uptime" {
+  name = "Number of seconds since Redis server start"
+
+  program_text = <<-EOF
+    data("redis.uptime").publish(label="Number of seconds since Redis server start")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_cpu_time" {
+  name = "System CPU consumed by the Redis server in seconds since server start"
+
+  program_text = <<-EOF
+    data("redis.cpu.time").publish(label="System CPU consumed by the Redis server in seconds since server start")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_clients_connected" {
+  name = "Number of client connections (excluding connections from replicas)"
+
+  program_text = <<-EOF
+    data("redis.clients.connected").publish(label="Number of client connections (excluding connections from replicas)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_clients_max_input_buffer" {
+  name = "Biggest input buffer among current client connections"
+
+  program_text = <<-EOF
+    data("redis.clients.max_input_buffer").publish(label="Biggest input buffer among current client connections")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_clients_max_output_buffer" {
+  name = "Longest output list among current client connections"
+
+  program_text = <<-EOF
+    data("redis.clients.max_output_buffer").publish(label="Longest output list among current client connections")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_clients_blocked" {
+  name = "Number of clients pending on a blocking call"
+
+  program_text = <<-EOF
+    data("redis.clients.blocked").publish(label="Number of clients pending on a blocking call")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_keys_expired" {
+  name = "Total number of key expiration events"
+
+  program_text = <<-EOF
+    data("redis.keys.expired").publish(label="Total number of key expiration events")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_keys_evicted" {
+  name = "Number of evicted keys due to maxmemory limit"
+
+  program_text = <<-EOF
+    data("redis.keys.evicted").publish(label="Number of evicted keys due to maxmemory limit")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_connections_received" {
+  name = "Total number of connections accepted by the server"
+
+  program_text = <<-EOF
+    data("redis.connections.received").publish(label="Total number of connections accepted by the server")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_connections_rejected" {
+  name = "Number of connections rejected because of maxclients limit"
+
+  program_text = <<-EOF
+    data("redis.connections.rejected").publish(label="Number of connections rejected because of maxclients limit")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_memory_used" {
+  name = "Total number of bytes allocated by Redis using its allocator"
+
+  program_text = <<-EOF
+    data("redis.memory.used").publish(label="Total number of bytes allocated by Redis using its allocator")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_memory_peak" {
+  name = "Peak memory consumed by Redis (in bytes)"
+
+  program_text = <<-EOF
+    data("redis.memory.peak").publish(label="Peak memory consumed by Redis (in bytes)")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_memory_rss" {
+  name = "Number of bytes that Redis allocated as seen by the operating system"
+
+  program_text = <<-EOF
+    data("redis.memory.rss").publish(label="Number of bytes that Redis allocated as seen by the operating system")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_memory_lua" {
+  name = "Number of bytes used by the Lua engine"
+
+  program_text = <<-EOF
+    data("redis.memory.lua").publish(label="Number of bytes used by the Lua engine")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_memory_fragmentation_ratio" {
+  name = "Ratio between used_memory_rss and used_memory"
+
+  program_text = <<-EOF
+    data("redis.memory.fragmentation_ratio").publish(label="Ratio between used_memory_rss and used_memory")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_rdb_changes_since_last_save" {
+  name = "Number of changes since the last dump"
+
+  program_text = <<-EOF
+    data("redis.rdb.changes_since_last_save").publish(label="Number of changes since the last dump")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_commands" {
+  name = "Number of commands processed per second"
+
+  program_text = <<-EOF
+    data("redis.commands").publish(label="Number of commands processed per second")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_commands_processed" {
+  name = "Total number of commands processed by the server"
+
+  program_text = <<-EOF
+    data("redis.commands.processed").publish(label="Total number of commands processed by the server")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_net_input" {
+  name = "The total number of bytes read from the network"
+
+  program_text = <<-EOF
+    data("redis.net.input").publish(label="The total number of bytes read from the network")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_net_output" {
+  name = "The total number of bytes written to the network"
+
+  program_text = <<-EOF
+    data("redis.net.output").publish(label="The total number of bytes written to the network")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_keyspace_hits" {
+  name = "Number of successful lookup of keys in the main dictionary"
+
+  program_text = <<-EOF
+    data("redis.keyspace.hits").publish(label="Number of successful lookup of keys in the main dictionary")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_keyspace_misses" {
+  name = "Number of failed lookup of keys in the main dictionary"
+
+  program_text = <<-EOF
+    data("redis.keyspace.misses").publish(label="Number of failed lookup of keys in the main dictionary")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_latest_fork" {
+  name = "Duration of the latest fork operation in microseconds"
+
+  program_text = <<-EOF
+    data("redis.latest_fork").publish(label="Duration of the latest fork operation in microseconds")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_slaves_connected" {
+  name = "Number of connected replicas"
+
+  program_text = <<-EOF
+    data("redis.slaves.connected").publish(label="Number of connected replicas")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_replication_backlog_first_byte_offset" {
+  name = "The master offset of the replication backlog buffer"
+
+  program_text = <<-EOF
+    data("redis.replication.backlog_first_byte_offset").publish(label="The master offset of the replication backlog buffer")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_replication_offset" {
+  name = "The server's current replication offset"
+
+  program_text = <<-EOF
+    data("redis.replication.offset").publish(label="The server's current replication offset")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_db_keys" {
+  name = "Number of keyspace keys"
+
+  program_text = <<-EOF
+    data("redis.db.keys").publish(label="Number of keyspace keys")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_db_expires" {
+  name = "Number of keyspace keys with an expiration"
+
+  program_text = <<-EOF
+    data("redis.db.expires").publish(label="Number of keyspace keys with an expiration")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "redis_db_avg_ttl" {
+  name = "Average keyspace keys TTL"
+
+  program_text = <<-EOF
+    data("redis.db.avg_ttl").publish(label="Average keyspace keys TTL")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/riakreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/riakreceiver_metadata.yaml.tf
@@ -1,0 +1,102 @@
+
+resource "signalfx_dashboard" "riakdashboard" {
+  name            = "riak"
+  dashboard_group = signalfx_dashboard_group.riakdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.riak_node_operation_count.id, signalfx_time_chart.riak_node_operation_time_mean.id, signalfx_time_chart.riak_node_read_repair_count.id, signalfx_time_chart.riak_memory_limit.id, signalfx_time_chart.riak_vnode_operation_count.id, signalfx_time_chart.riak_vnode_index_operation_count.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "riakdashboardgroup0" {
+  name        = "riak generated OTel dashboard group"
+  description = "riak generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "riak_node_operation_count" {
+  name = "The number of operations performed by the node."
+
+  program_text = <<-EOF
+    data("riak.node.operation.count").publish(label="The number of operations performed by the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "riak_node_operation_time_mean" {
+  name = "The mean time between request and response for operations performed by the node over the last minute."
+
+  program_text = <<-EOF
+    data("riak.node.operation.time.mean").publish(label="The mean time between request and response for operations performed by the node over the last minute.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "riak_node_read_repair_count" {
+  name = "The number of read repairs performed by the node."
+
+  program_text = <<-EOF
+    data("riak.node.read_repair.count").publish(label="The number of read repairs performed by the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "riak_memory_limit" {
+  name = "The amount of memory allocated to the node."
+
+  program_text = <<-EOF
+    data("riak.memory.limit").publish(label="The amount of memory allocated to the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "riak_vnode_operation_count" {
+  name = "The number of operations performed by vnodes on the node."
+
+  program_text = <<-EOF
+    data("riak.vnode.operation.count").publish(label="The number of operations performed by vnodes on the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "riak_vnode_index_operation_count" {
+  name = "The number of index operations performed by vnodes on the node."
+
+  program_text = <<-EOF
+    data("riak.vnode.index.operation.count").publish(label="The number of index operations performed by vnodes on the node.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/saphanareceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/saphanareceiver_metadata.yaml.tf
@@ -1,0 +1,648 @@
+
+resource "signalfx_dashboard" "saphanadashboard" {
+  name            = "saphana"
+  dashboard_group = signalfx_dashboard_group.saphanadashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.saphana_connection_count.id, signalfx_time_chart.saphana_cpu_used.id, signalfx_time_chart.saphana_alert_count.id, signalfx_time_chart.saphana_uptime.id, signalfx_time_chart.saphana_replication_backlog_time.id, signalfx_time_chart.saphana_replication_backlog_size.id, signalfx_time_chart.saphana_replication_average_time.id, signalfx_time_chart.saphana_backup_latest.id, signalfx_time_chart.saphana_transaction_count.id, signalfx_time_chart.saphana_transaction_blocked.id, signalfx_time_chart.saphana_license_expiration_time.id, signalfx_time_chart.saphana_license_limit.id, signalfx_time_chart.saphana_license_peak.id, signalfx_time_chart.saphana_instance_memory_current.id, signalfx_time_chart.saphana_instance_memory_used_peak.id, signalfx_time_chart.saphana_instance_code_size.id, signalfx_time_chart.saphana_instance_memory_shared_allocated.id, signalfx_time_chart.saphana_host_memory_current.id, signalfx_time_chart.saphana_host_swap_current.id, signalfx_time_chart.saphana_column_memory_used.id, signalfx_time_chart.saphana_row_store_memory_used.id, signalfx_time_chart.saphana_component_memory_used.id, signalfx_time_chart.saphana_schema_memory_used_current.id, signalfx_time_chart.saphana_schema_memory_used_max.id, signalfx_time_chart.saphana_schema_record_count.id, signalfx_time_chart.saphana_schema_record_compressed_count.id, signalfx_time_chart.saphana_schema_operation_count.id, signalfx_time_chart.saphana_service_count.id, signalfx_time_chart.saphana_service_thread_count.id, signalfx_time_chart.saphana_service_memory_used.id, signalfx_time_chart.saphana_service_code_size.id, signalfx_time_chart.saphana_service_stack_size.id, signalfx_time_chart.saphana_service_memory_heap_current.id, signalfx_time_chart.saphana_service_memory_shared_current.id, signalfx_time_chart.saphana_service_memory_compactors_allocated.id, signalfx_time_chart.saphana_service_memory_compactors_freeable.id, signalfx_time_chart.saphana_service_memory_limit.id, signalfx_time_chart.saphana_service_memory_effective_limit.id, signalfx_time_chart.saphana_disk_size_current.id, signalfx_time_chart.saphana_volume_operation_count.id, signalfx_time_chart.saphana_volume_operation_size.id, signalfx_time_chart.saphana_volume_operation_time.id, signalfx_time_chart.saphana_network_request_count.id, signalfx_time_chart.saphana_network_request_finished_count.id, signalfx_time_chart.saphana_network_request_average_time.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "saphanadashboardgroup0" {
+  name        = "saphana generated OTel dashboard group"
+  description = "saphana generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "saphana_connection_count" {
+  name = "The number of current connections."
+
+  program_text = <<-EOF
+    data("saphana.connection.count").publish(label="The number of current connections.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_cpu_used" {
+  name = "Total CPU time spent."
+
+  program_text = <<-EOF
+    data("saphana.cpu.used").publish(label="Total CPU time spent.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_alert_count" {
+  name = "Number of current alerts."
+
+  program_text = <<-EOF
+    data("saphana.alert.count").publish(label="Number of current alerts.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_uptime" {
+  name = "The uptime of the database."
+
+  program_text = <<-EOF
+    data("saphana.uptime").publish(label="The uptime of the database.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_replication_backlog_time" {
+  name = "The current replication backlog."
+
+  program_text = <<-EOF
+    data("saphana.replication.backlog.time").publish(label="The current replication backlog.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_replication_backlog_size" {
+  name = "The current replication backlog size."
+
+  program_text = <<-EOF
+    data("saphana.replication.backlog.size").publish(label="The current replication backlog size.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_replication_average_time" {
+  name = "The average amount of time consumed replicating a log."
+
+  program_text = <<-EOF
+    data("saphana.replication.average_time").publish(label="The average amount of time consumed replicating a log.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_backup_latest" {
+  name = "The age of the latest backup by start time."
+
+  program_text = <<-EOF
+    data("saphana.backup.latest").publish(label="The age of the latest backup by start time.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_transaction_count" {
+  name = "The number of transactions."
+
+  program_text = <<-EOF
+    data("saphana.transaction.count").publish(label="The number of transactions.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_transaction_blocked" {
+  name = "The number of transactions waiting for a lock."
+
+  program_text = <<-EOF
+    data("saphana.transaction.blocked").publish(label="The number of transactions waiting for a lock.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_license_expiration_time" {
+  name = "The amount of time remaining before license expiration."
+
+  program_text = <<-EOF
+    data("saphana.license.expiration.time").publish(label="The amount of time remaining before license expiration.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_license_limit" {
+  name = "The allowed product usage as specified by the license (for example, main memory)."
+
+  program_text = <<-EOF
+    data("saphana.license.limit").publish(label="The allowed product usage as specified by the license (for example, main memory).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_license_peak" {
+  name = "The peak product usage value during last 13 months, measured periodically."
+
+  program_text = <<-EOF
+    data("saphana.license.peak").publish(label="The peak product usage value during last 13 months, measured periodically.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_instance_memory_current" {
+  name = "The size of the memory pool for all SAP HANA processes."
+
+  program_text = <<-EOF
+    data("saphana.instance.memory.current").publish(label="The size of the memory pool for all SAP HANA processes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_instance_memory_used_peak" {
+  name = "The peak memory from the memory pool used by SAP HANA processes since the instance started (this is a sample-based value)."
+
+  program_text = <<-EOF
+    data("saphana.instance.memory.used.peak").publish(label="The peak memory from the memory pool used by SAP HANA processes since the instance started (this is a sample-based value).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_instance_code_size" {
+  name = "The instance code size, including shared libraries of SAP HANA processes."
+
+  program_text = <<-EOF
+    data("saphana.instance.code_size").publish(label="The instance code size, including shared libraries of SAP HANA processes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_instance_memory_shared_allocated" {
+  name = "The shared memory size of SAP HANA processes."
+
+  program_text = <<-EOF
+    data("saphana.instance.memory.shared.allocated").publish(label="The shared memory size of SAP HANA processes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_host_memory_current" {
+  name = "The amount of physical memory on the host."
+
+  program_text = <<-EOF
+    data("saphana.host.memory.current").publish(label="The amount of physical memory on the host.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_host_swap_current" {
+  name = "The amount of swap space on the host."
+
+  program_text = <<-EOF
+    data("saphana.host.swap.current").publish(label="The amount of swap space on the host.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_column_memory_used" {
+  name = "The memory used in all columns."
+
+  program_text = <<-EOF
+    data("saphana.column.memory.used").publish(label="The memory used in all columns.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_row_store_memory_used" {
+  name = "The used memory for all row tables."
+
+  program_text = <<-EOF
+    data("saphana.row_store.memory.used").publish(label="The used memory for all row tables.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_component_memory_used" {
+  name = "The memory used in components."
+
+  program_text = <<-EOF
+    data("saphana.component.memory.used").publish(label="The memory used in components.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_schema_memory_used_current" {
+  name = "The memory size for all tables in schema."
+
+  program_text = <<-EOF
+    data("saphana.schema.memory.used.current").publish(label="The memory size for all tables in schema.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_schema_memory_used_max" {
+  name = "The estimated maximum memory consumption for all fully loaded tables in schema (data for open transactions is not included)."
+
+  program_text = <<-EOF
+    data("saphana.schema.memory.used.max").publish(label="The estimated maximum memory consumption for all fully loaded tables in schema (data for open transactions is not included).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_schema_record_count" {
+  name = "The number of records for all tables in schema."
+
+  program_text = <<-EOF
+    data("saphana.schema.record.count").publish(label="The number of records for all tables in schema.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_schema_record_compressed_count" {
+  name = "The number of entries in main during the last optimize compression run for all tables in schema."
+
+  program_text = <<-EOF
+    data("saphana.schema.record.compressed.count").publish(label="The number of entries in main during the last optimize compression run for all tables in schema.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_schema_operation_count" {
+  name = "The number of operations done on all tables in schema."
+
+  program_text = <<-EOF
+    data("saphana.schema.operation.count").publish(label="The number of operations done on all tables in schema.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_count" {
+  name = "The number of services in a given status."
+
+  program_text = <<-EOF
+    data("saphana.service.count").publish(label="The number of services in a given status.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_thread_count" {
+  name = "The number of service threads in a given status."
+
+  program_text = <<-EOF
+    data("saphana.service.thread.count").publish(label="The number of service threads in a given status.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_memory_used" {
+  name = "The used memory from the operating system perspective."
+
+  program_text = <<-EOF
+    data("saphana.service.memory.used").publish(label="The used memory from the operating system perspective.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_code_size" {
+  name = "The service code size, including shared libraries."
+
+  program_text = <<-EOF
+    data("saphana.service.code_size").publish(label="The service code size, including shared libraries.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_stack_size" {
+  name = "The service stack size."
+
+  program_text = <<-EOF
+    data("saphana.service.stack_size").publish(label="The service stack size.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_memory_heap_current" {
+  name = "The size of the heap portion of the memory pool."
+
+  program_text = <<-EOF
+    data("saphana.service.memory.heap.current").publish(label="The size of the heap portion of the memory pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_memory_shared_current" {
+  name = "The size of the shared portion of the memory pool."
+
+  program_text = <<-EOF
+    data("saphana.service.memory.shared.current").publish(label="The size of the shared portion of the memory pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_memory_compactors_allocated" {
+  name = "The part of the memory pool that can potentially (if unpinned) be freed during a memory shortage."
+
+  program_text = <<-EOF
+    data("saphana.service.memory.compactors.allocated").publish(label="The part of the memory pool that can potentially (if unpinned) be freed during a memory shortage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_memory_compactors_freeable" {
+  name = "The memory that can be freed during a memory shortage."
+
+  program_text = <<-EOF
+    data("saphana.service.memory.compactors.freeable").publish(label="The memory that can be freed during a memory shortage.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_memory_limit" {
+  name = "The configured maximum memory pool size."
+
+  program_text = <<-EOF
+    data("saphana.service.memory.limit").publish(label="The configured maximum memory pool size.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_service_memory_effective_limit" {
+  name = "The effective maximum memory pool size, calculated considering the pool sizes of other processes."
+
+  program_text = <<-EOF
+    data("saphana.service.memory.effective_limit").publish(label="The effective maximum memory pool size, calculated considering the pool sizes of other processes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_disk_size_current" {
+  name = "The disk size."
+
+  program_text = <<-EOF
+    data("saphana.disk.size.current").publish(label="The disk size.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_volume_operation_count" {
+  name = "The number of operations executed."
+
+  program_text = <<-EOF
+    data("saphana.volume.operation.count").publish(label="The number of operations executed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_volume_operation_size" {
+  name = "The size of operations executed."
+
+  program_text = <<-EOF
+    data("saphana.volume.operation.size").publish(label="The size of operations executed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_volume_operation_time" {
+  name = "The time spent executing operations."
+
+  program_text = <<-EOF
+    data("saphana.volume.operation.time").publish(label="The time spent executing operations.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_network_request_count" {
+  name = "The number of active and pending service requests."
+
+  program_text = <<-EOF
+    data("saphana.network.request.count").publish(label="The number of active and pending service requests.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_network_request_finished_count" {
+  name = "The number of service requests that have completed."
+
+  program_text = <<-EOF
+    data("saphana.network.request.finished.count").publish(label="The number of service requests that have completed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "saphana_network_request_average_time" {
+  name = "The average response time calculated over recent requests"
+
+  program_text = <<-EOF
+    data("saphana.network.request.average_time").publish(label="The average response time calculated over recent requests")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/snowflakereceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/snowflakereceiver_metadata.yaml.tf
@@ -1,0 +1,508 @@
+
+resource "signalfx_dashboard" "snowflakedashboard" {
+  name            = "snowflake"
+  dashboard_group = signalfx_dashboard_group.snowflakedashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.snowflake_billing_cloud_service_total.id, signalfx_time_chart.snowflake_billing_total_credit_total.id, signalfx_time_chart.snowflake_billing_virtual_warehouse_total.id, signalfx_time_chart.snowflake_billing_warehouse_cloud_service_total.id, signalfx_time_chart.snowflake_billing_warehouse_total_credit_total.id, signalfx_time_chart.snowflake_billing_warehouse_virtual_warehouse_total.id, signalfx_time_chart.snowflake_logins_total.id, signalfx_time_chart.snowflake_query_blocked.id, signalfx_time_chart.snowflake_query_executed.id, signalfx_time_chart.snowflake_query_queued_overload.id, signalfx_time_chart.snowflake_query_queued_provision.id, signalfx_time_chart.snowflake_database_query_count.id, signalfx_time_chart.snowflake_database_bytes_scanned_avg.id, signalfx_time_chart.snowflake_query_bytes_deleted_avg.id, signalfx_time_chart.snowflake_query_bytes_spilled_local_avg.id, signalfx_time_chart.snowflake_query_bytes_spilled_remote_avg.id, signalfx_time_chart.snowflake_query_bytes_written_avg.id, signalfx_time_chart.snowflake_query_compilation_time_avg.id, signalfx_time_chart.snowflake_query_data_scanned_cache_avg.id, signalfx_time_chart.snowflake_query_execution_time_avg.id, signalfx_time_chart.snowflake_query_partitions_scanned_avg.id, signalfx_time_chart.snowflake_queued_overload_time_avg.id, signalfx_time_chart.snowflake_queued_provisioning_time_avg.id, signalfx_time_chart.snowflake_queued_repair_time_avg.id, signalfx_time_chart.snowflake_rows_inserted_avg.id, signalfx_time_chart.snowflake_rows_deleted_avg.id, signalfx_time_chart.snowflake_rows_produced_avg.id, signalfx_time_chart.snowflake_rows_unloaded_avg.id, signalfx_time_chart.snowflake_rows_updated_avg.id, signalfx_time_chart.snowflake_total_elapsed_time_avg.id, signalfx_time_chart.snowflake_session_id_count.id, signalfx_time_chart.snowflake_pipe_credits_used_total.id, signalfx_time_chart.snowflake_storage_storage_bytes_total.id, signalfx_time_chart.snowflake_storage_stage_bytes_total.id, signalfx_time_chart.snowflake_storage_failsafe_bytes_total.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "snowflakedashboardgroup0" {
+  name        = "snowflake generated OTel dashboard group"
+  description = "snowflake generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "snowflake_billing_cloud_service_total" {
+  name = "Reported total credits used in the cloud service over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.billing.cloud_service.total").publish(label="Reported total credits used in the cloud service over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_billing_total_credit_total" {
+  name = "Reported total credits used across account over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.billing.total_credit.total").publish(label="Reported total credits used across account over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_billing_virtual_warehouse_total" {
+  name = "Reported total credits used by virtual warehouse service over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.billing.virtual_warehouse.total").publish(label="Reported total credits used by virtual warehouse service over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_billing_warehouse_cloud_service_total" {
+  name = "Credits used across cloud service for given warehouse over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.billing.warehouse.cloud_service.total").publish(label="Credits used across cloud service for given warehouse over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_billing_warehouse_total_credit_total" {
+  name = "Total credits used associated with given warehouse over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.billing.warehouse.total_credit.total").publish(label="Total credits used associated with given warehouse over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_billing_warehouse_virtual_warehouse_total" {
+  name = "Total credits used by virtual warehouse service for given warehouse over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.billing.warehouse.virtual_warehouse.total").publish(label="Total credits used by virtual warehouse service for given warehouse over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_logins_total" {
+  name = "Total login attempts for account over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.logins.total").publish(label="Total login attempts for account over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_blocked" {
+  name = "Blocked query count for warehouse over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.blocked").publish(label="Blocked query count for warehouse over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_executed" {
+  name = "Executed query count for warehouse over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.executed").publish(label="Executed query count for warehouse over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_queued_overload" {
+  name = "Overloaded query count for warehouse over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.queued_overload").publish(label="Overloaded query count for warehouse over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_queued_provision" {
+  name = "Number of compute resources queued for provisioning over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.queued_provision").publish(label="Number of compute resources queued for provisioning over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_database_query_count" {
+  name = "Total query count for database over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.database.query.count").publish(label="Total query count for database over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_database_bytes_scanned_avg" {
+  name = "Average bytes scanned in a database over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.database.bytes_scanned.avg").publish(label="Average bytes scanned in a database over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_bytes_deleted_avg" {
+  name = "Average bytes deleted in database over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.bytes_deleted.avg").publish(label="Average bytes deleted in database over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_bytes_spilled_local_avg" {
+  name = "Avergae bytes spilled (intermediate results do not fit in memory) by local storage over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.bytes_spilled.local.avg").publish(label="Avergae bytes spilled (intermediate results do not fit in memory) by local storage over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_bytes_spilled_remote_avg" {
+  name = "Avergae bytes spilled (intermediate results do not fit in memory) by remote storage over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.bytes_spilled.remote.avg").publish(label="Avergae bytes spilled (intermediate results do not fit in memory) by remote storage over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_bytes_written_avg" {
+  name = "Average bytes written by database over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.bytes_written.avg").publish(label="Average bytes written by database over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_compilation_time_avg" {
+  name = "Average time taken to compile query over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.compilation_time.avg").publish(label="Average time taken to compile query over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_data_scanned_cache_avg" {
+  name = "Average percentage of data scanned from cache over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.data_scanned_cache.avg").publish(label="Average percentage of data scanned from cache over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_execution_time_avg" {
+  name = "Average time spent executing queries in database over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.execution_time.avg").publish(label="Average time spent executing queries in database over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_query_partitions_scanned_avg" {
+  name = "Number of partitions scanned during query so far over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.query.partitions_scanned.avg").publish(label="Number of partitions scanned during query so far over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_queued_overload_time_avg" {
+  name = "Average time spent in warehouse queue due to warehouse being overloaded over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.queued_overload_time.avg").publish(label="Average time spent in warehouse queue due to warehouse being overloaded over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_queued_provisioning_time_avg" {
+  name = "Average time spent in warehouse queue waiting for resources to provision over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.queued_provisioning_time.avg").publish(label="Average time spent in warehouse queue waiting for resources to provision over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_queued_repair_time_avg" {
+  name = "Average time spent in warehouse queue waiting for compute resources to be repaired over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.queued_repair_time.avg").publish(label="Average time spent in warehouse queue waiting for compute resources to be repaired over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_rows_inserted_avg" {
+  name = "Number of rows inserted into a table (or tables) over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.rows_inserted.avg").publish(label="Number of rows inserted into a table (or tables) over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_rows_deleted_avg" {
+  name = "Number of rows deleted from a table (or tables) over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.rows_deleted.avg").publish(label="Number of rows deleted from a table (or tables) over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_rows_produced_avg" {
+  name = "Average number of rows produced by statement over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.rows_produced.avg").publish(label="Average number of rows produced by statement over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_rows_unloaded_avg" {
+  name = "Average number of rows unloaded during data export over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.rows_unloaded.avg").publish(label="Average number of rows unloaded during data export over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_rows_updated_avg" {
+  name = "Average number of rows updated in a table over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.rows_updated.avg").publish(label="Average number of rows updated in a table over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_total_elapsed_time_avg" {
+  name = "Average elapsed time over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.total_elapsed_time.avg").publish(label="Average elapsed time over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_session_id_count" {
+  name = "Distinct session id's associated with snowflake username over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.session_id.count").publish(label="Distinct session id's associated with snowflake username over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_pipe_credits_used_total" {
+  name = "Snow pipe credits contotaled over the last 24 hour window."
+
+  program_text = <<-EOF
+    data("snowflake.pipe.credits_used.total").publish(label="Snow pipe credits contotaled over the last 24 hour window.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_storage_storage_bytes_total" {
+  name = "Number of bytes of table storage used, including bytes for data currently in Time Travel."
+
+  program_text = <<-EOF
+    data("snowflake.storage.storage_bytes.total").publish(label="Number of bytes of table storage used, including bytes for data currently in Time Travel.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_storage_stage_bytes_total" {
+  name = "Number of bytes of stage storage used by files in all internal stages (named, table, user)."
+
+  program_text = <<-EOF
+    data("snowflake.storage.stage_bytes.total").publish(label="Number of bytes of stage storage used by files in all internal stages (named, table, user).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "snowflake_storage_failsafe_bytes_total" {
+  name = "Number of bytes of data in Fail-safe."
+
+  program_text = <<-EOF
+    data("snowflake.storage.failsafe_bytes.total").publish(label="Number of bytes of data in Fail-safe.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/splunkenterprisereceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/splunkenterprisereceiver_metadata.yaml.tf
@@ -1,0 +1,172 @@
+
+resource "signalfx_dashboard" "splunkenterprisedashboard" {
+  name            = "splunkenterprise"
+  dashboard_group = signalfx_dashboard_group.splunkenterprisedashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.splunk_license_index_usage.id, signalfx_time_chart.splunk_indexer_throughput.id, signalfx_time_chart.splunk_data_indexes_extended_total_size.id, signalfx_time_chart.splunk_data_indexes_extended_event_count.id, signalfx_time_chart.splunk_data_indexes_extended_bucket_count.id, signalfx_time_chart.splunk_data_indexes_extended_raw_size.id, signalfx_time_chart.splunk_data_indexes_extended_bucket_event_count.id, signalfx_time_chart.splunk_data_indexes_extended_bucket_hot_count.id, signalfx_time_chart.splunk_data_indexes_extended_bucket_warm_count.id, signalfx_time_chart.splunk_server_introspection_queues_current.id, signalfx_time_chart.splunk_server_introspection_queues_current_bytes.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "splunkenterprisedashboardgroup0" {
+  name        = "splunkenterprise generated OTel dashboard group"
+  description = "splunkenterprise generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "splunk_license_index_usage" {
+  name = "Gauge tracking the indexed license usage per index"
+
+  program_text = <<-EOF
+    data("splunk.license.index.usage").publish(label="Gauge tracking the indexed license usage per index")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "splunk_indexer_throughput" {
+  name = "Gauge tracking average bytes per second throughput of indexer"
+
+  program_text = <<-EOF
+    data("splunk.indexer.throughput").publish(label="Gauge tracking average bytes per second throughput of indexer")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "splunk_data_indexes_extended_total_size" {
+  name = "Size in bytes on disk of this index"
+
+  program_text = <<-EOF
+    data("splunk.data.indexes.extended.total.size").publish(label="Size in bytes on disk of this index")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "splunk_data_indexes_extended_event_count" {
+  name = "Count of events for index, excluding frozen events. Approximately equal to the event_count sum of all buckets."
+
+  program_text = <<-EOF
+    data("splunk.data.indexes.extended.event.count").publish(label="Count of events for index, excluding frozen events. Approximately equal to the event_count sum of all buckets.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "splunk_data_indexes_extended_bucket_count" {
+  name = "Count of buckets per index"
+
+  program_text = <<-EOF
+    data("splunk.data.indexes.extended.bucket.count").publish(label="Count of buckets per index")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "splunk_data_indexes_extended_raw_size" {
+  name = "Size in bytes on disk of the <bucket>/rawdata/ directories of all buckets in this index, excluding frozen"
+
+  program_text = <<-EOF
+    data("splunk.data.indexes.extended.raw.size").publish(label="Size in bytes on disk of the <bucket>/rawdata/ directories of all buckets in this index, excluding frozen")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "splunk_data_indexes_extended_bucket_event_count" {
+  name = "Count of events in this bucket super-directory"
+
+  program_text = <<-EOF
+    data("splunk.data.indexes.extended.bucket.event.count").publish(label="Count of events in this bucket super-directory")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "splunk_data_indexes_extended_bucket_hot_count" {
+  name = "(If size > 0) Number of hot buckets"
+
+  program_text = <<-EOF
+    data("splunk.data.indexes.extended.bucket.hot.count").publish(label="(If size > 0) Number of hot buckets")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "splunk_data_indexes_extended_bucket_warm_count" {
+  name = "(If size > 0) Number of warm buckets"
+
+  program_text = <<-EOF
+    data("splunk.data.indexes.extended.bucket.warm.count").publish(label="(If size > 0) Number of warm buckets")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "splunk_server_introspection_queues_current" {
+  name = "Gauge tracking current length of queue"
+
+  program_text = <<-EOF
+    data("splunk.server.introspection.queues.current").publish(label="Gauge tracking current length of queue")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "splunk_server_introspection_queues_current_bytes" {
+  name = "Gauge tracking current bytes waiting in queue"
+
+  program_text = <<-EOF
+    data("splunk.server.introspection.queues.current.bytes").publish(label="Gauge tracking current bytes waiting in queue")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/sqlserverreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/sqlserverreceiver_metadata.yaml.tf
@@ -1,0 +1,298 @@
+
+resource "signalfx_dashboard" "sqlserverdashboard" {
+  name            = "sqlserver"
+  dashboard_group = signalfx_dashboard_group.sqlserverdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.sqlserver_user_connection_count.id, signalfx_time_chart.sqlserver_lock_wait_time_avg.id, signalfx_time_chart.sqlserver_lock_wait_rate.id, signalfx_time_chart.sqlserver_batch_request_rate.id, signalfx_time_chart.sqlserver_batch_sql_compilation_rate.id, signalfx_time_chart.sqlserver_batch_sql_recompilation_rate.id, signalfx_time_chart.sqlserver_page_buffer_cache_hit_ratio.id, signalfx_time_chart.sqlserver_page_life_expectancy.id, signalfx_time_chart.sqlserver_page_split_rate.id, signalfx_time_chart.sqlserver_page_lazy_write_rate.id, signalfx_time_chart.sqlserver_page_checkpoint_flush_rate.id, signalfx_time_chart.sqlserver_page_operation_rate.id, signalfx_time_chart.sqlserver_transaction_log_growth_count.id, signalfx_time_chart.sqlserver_transaction_log_shrink_count.id, signalfx_time_chart.sqlserver_transaction_log_usage.id, signalfx_time_chart.sqlserver_transaction_log_flush_wait_rate.id, signalfx_time_chart.sqlserver_transaction_log_flush_rate.id, signalfx_time_chart.sqlserver_transaction_log_flush_data_rate.id, signalfx_time_chart.sqlserver_transaction_rate.id, signalfx_time_chart.sqlserver_transaction_write_rate.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "sqlserverdashboardgroup0" {
+  name        = "sqlserver generated OTel dashboard group"
+  description = "sqlserver generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "sqlserver_user_connection_count" {
+  name = "Number of users connected to the SQL Server."
+
+  program_text = <<-EOF
+    data("sqlserver.user.connection.count").publish(label="Number of users connected to the SQL Server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_lock_wait_time_avg" {
+  name = "Average wait time for all lock requests that had to wait."
+
+  program_text = <<-EOF
+    data("sqlserver.lock.wait_time.avg").publish(label="Average wait time for all lock requests that had to wait.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_lock_wait_rate" {
+  name = "Number of lock requests resulting in a wait."
+
+  program_text = <<-EOF
+    data("sqlserver.lock.wait.rate").publish(label="Number of lock requests resulting in a wait.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_batch_request_rate" {
+  name = "Number of batch requests received by SQL Server."
+
+  program_text = <<-EOF
+    data("sqlserver.batch.request.rate").publish(label="Number of batch requests received by SQL Server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_batch_sql_compilation_rate" {
+  name = "Number of SQL compilations needed."
+
+  program_text = <<-EOF
+    data("sqlserver.batch.sql_compilation.rate").publish(label="Number of SQL compilations needed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_batch_sql_recompilation_rate" {
+  name = "Number of SQL recompilations needed."
+
+  program_text = <<-EOF
+    data("sqlserver.batch.sql_recompilation.rate").publish(label="Number of SQL recompilations needed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_page_buffer_cache_hit_ratio" {
+  name = "Pages found in the buffer pool without having to read from disk."
+
+  program_text = <<-EOF
+    data("sqlserver.page.buffer_cache.hit_ratio").publish(label="Pages found in the buffer pool without having to read from disk.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_page_life_expectancy" {
+  name = "Time a page will stay in the buffer pool."
+
+  program_text = <<-EOF
+    data("sqlserver.page.life_expectancy").publish(label="Time a page will stay in the buffer pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_page_split_rate" {
+  name = "Number of pages split as a result of overflowing index pages."
+
+  program_text = <<-EOF
+    data("sqlserver.page.split.rate").publish(label="Number of pages split as a result of overflowing index pages.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_page_lazy_write_rate" {
+  name = "Number of lazy writes moving dirty pages to disk."
+
+  program_text = <<-EOF
+    data("sqlserver.page.lazy_write.rate").publish(label="Number of lazy writes moving dirty pages to disk.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_page_checkpoint_flush_rate" {
+  name = "Number of pages flushed by operations requiring dirty pages to be flushed."
+
+  program_text = <<-EOF
+    data("sqlserver.page.checkpoint.flush.rate").publish(label="Number of pages flushed by operations requiring dirty pages to be flushed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_page_operation_rate" {
+  name = "Number of physical database page operations issued."
+
+  program_text = <<-EOF
+    data("sqlserver.page.operation.rate").publish(label="Number of physical database page operations issued.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_transaction_log_growth_count" {
+  name = "Total number of transaction log expansions for a database."
+
+  program_text = <<-EOF
+    data("sqlserver.transaction_log.growth.count").publish(label="Total number of transaction log expansions for a database.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_transaction_log_shrink_count" {
+  name = "Total number of transaction log shrinks for a database."
+
+  program_text = <<-EOF
+    data("sqlserver.transaction_log.shrink.count").publish(label="Total number of transaction log shrinks for a database.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_transaction_log_usage" {
+  name = "Percent of transaction log space used."
+
+  program_text = <<-EOF
+    data("sqlserver.transaction_log.usage").publish(label="Percent of transaction log space used.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_transaction_log_flush_wait_rate" {
+  name = "Number of commits waiting for a transaction log flush."
+
+  program_text = <<-EOF
+    data("sqlserver.transaction_log.flush.wait.rate").publish(label="Number of commits waiting for a transaction log flush.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_transaction_log_flush_rate" {
+  name = "Number of log flushes."
+
+  program_text = <<-EOF
+    data("sqlserver.transaction_log.flush.rate").publish(label="Number of log flushes.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_transaction_log_flush_data_rate" {
+  name = "Total number of log bytes flushed."
+
+  program_text = <<-EOF
+    data("sqlserver.transaction_log.flush.data.rate").publish(label="Total number of log bytes flushed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_transaction_rate" {
+  name = "Number of transactions started for the database (not including XTP-only transactions)."
+
+  program_text = <<-EOF
+    data("sqlserver.transaction.rate").publish(label="Number of transactions started for the database (not including XTP-only transactions).")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sqlserver_transaction_write_rate" {
+  name = "Number of transactions that wrote to the database and committed."
+
+  program_text = <<-EOF
+    data("sqlserver.transaction.write.rate").publish(label="Number of transactions that wrote to the database and committed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/sshcheckreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/sshcheckreceiver_metadata.yaml.tf
@@ -1,0 +1,102 @@
+
+resource "signalfx_dashboard" "sshcheckdashboard" {
+  name            = "sshcheck"
+  dashboard_group = signalfx_dashboard_group.sshcheckdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.sshcheck_status.id, signalfx_time_chart.sshcheck_duration.id, signalfx_time_chart.sshcheck_error.id, signalfx_time_chart.sshcheck_sftp_status.id, signalfx_time_chart.sshcheck_sftp_duration.id, signalfx_time_chart.sshcheck_sftp_error.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "sshcheckdashboardgroup0" {
+  name        = "sshcheck generated OTel dashboard group"
+  description = "sshcheck generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "sshcheck_status" {
+  name = "1 if the SSH client successfully connected, otherwise 0."
+
+  program_text = <<-EOF
+    data("sshcheck.status").publish(label="1 if the SSH client successfully connected, otherwise 0.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sshcheck_duration" {
+  name = "Measures the duration of SSH connection."
+
+  program_text = <<-EOF
+    data("sshcheck.duration").publish(label="Measures the duration of SSH connection.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sshcheck_error" {
+  name = "Records errors occurring during SSH check."
+
+  program_text = <<-EOF
+    data("sshcheck.error").publish(label="Records errors occurring during SSH check.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sshcheck_sftp_status" {
+  name = "1 if the SFTP server replied to request, otherwise 0."
+
+  program_text = <<-EOF
+    data("sshcheck.sftp_status").publish(label="1 if the SFTP server replied to request, otherwise 0.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sshcheck_sftp_duration" {
+  name = "Measures SFTP request duration."
+
+  program_text = <<-EOF
+    data("sshcheck.sftp_duration").publish(label="Measures SFTP request duration.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "sshcheck_sftp_error" {
+  name = "Records errors occurring during SFTP check."
+
+  program_text = <<-EOF
+    data("sshcheck.sftp_error").publish(label="Records errors occurring during SFTP check.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/vcenterreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/vcenterreceiver_metadata.yaml.tf
@@ -1,0 +1,564 @@
+
+resource "signalfx_dashboard" "vcenterdashboard" {
+  name            = "vcenter"
+  dashboard_group = signalfx_dashboard_group.vcenterdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.vcenter_cluster_cpu_limit.id, signalfx_time_chart.vcenter_cluster_cpu_effective.id, signalfx_time_chart.vcenter_cluster_memory_limit.id, signalfx_time_chart.vcenter_cluster_memory_effective.id, signalfx_time_chart.vcenter_cluster_memory_used.id, signalfx_time_chart.vcenter_cluster_vm_count.id, signalfx_time_chart.vcenter_cluster_host_count.id, signalfx_time_chart.vcenter_datastore_disk_usage.id, signalfx_time_chart.vcenter_datastore_disk_utilization.id, signalfx_time_chart.vcenter_host_cpu_utilization.id, signalfx_time_chart.vcenter_host_cpu_usage.id, signalfx_time_chart.vcenter_host_disk_throughput.id, signalfx_time_chart.vcenter_host_disk_latency_avg.id, signalfx_time_chart.vcenter_host_disk_latency_max.id, signalfx_time_chart.vcenter_host_memory_utilization.id, signalfx_time_chart.vcenter_host_memory_usage.id, signalfx_time_chart.vcenter_host_network_throughput.id, signalfx_time_chart.vcenter_host_network_usage.id, signalfx_time_chart.vcenter_host_network_packet_errors.id, signalfx_time_chart.vcenter_host_network_packet_count.id, signalfx_time_chart.vcenter_resource_pool_memory_usage.id, signalfx_time_chart.vcenter_resource_pool_memory_shares.id, signalfx_time_chart.vcenter_resource_pool_cpu_usage.id, signalfx_time_chart.vcenter_resource_pool_cpu_shares.id, signalfx_time_chart.vcenter_vm_memory_ballooned.id, signalfx_time_chart.vcenter_vm_memory_usage.id, signalfx_time_chart.vcenter_vm_memory_swapped.id, signalfx_time_chart.vcenter_vm_memory_swapped_ssd.id, signalfx_time_chart.vcenter_vm_disk_usage.id, signalfx_time_chart.vcenter_vm_disk_utilization.id, signalfx_time_chart.vcenter_vm_disk_latency_avg.id, signalfx_time_chart.vcenter_vm_disk_latency_max.id, signalfx_time_chart.vcenter_vm_disk_throughput.id, signalfx_time_chart.vcenter_vm_network_throughput.id, signalfx_time_chart.vcenter_vm_network_packet_count.id, signalfx_time_chart.vcenter_vm_network_usage.id, signalfx_time_chart.vcenter_vm_cpu_utilization.id, signalfx_time_chart.vcenter_vm_cpu_usage.id, signalfx_time_chart.vcenter_vm_memory_utilization.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "vcenterdashboardgroup0" {
+  name        = "vcenter generated OTel dashboard group"
+  description = "vcenter generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "vcenter_cluster_cpu_limit" {
+  name = "The amount of CPU available to the cluster."
+
+  program_text = <<-EOF
+    data("vcenter.cluster.cpu.limit").publish(label="The amount of CPU available to the cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_cluster_cpu_effective" {
+  name = "The effective CPU available to the cluster. This value excludes CPU from hosts in maintenance mode or are unresponsive."
+
+  program_text = <<-EOF
+    data("vcenter.cluster.cpu.effective").publish(label="The effective CPU available to the cluster. This value excludes CPU from hosts in maintenance mode or are unresponsive.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_cluster_memory_limit" {
+  name = "The available memory of the cluster."
+
+  program_text = <<-EOF
+    data("vcenter.cluster.memory.limit").publish(label="The available memory of the cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_cluster_memory_effective" {
+  name = "The effective memory of the cluster. This value excludes memory from hosts in maintenance mode or are unresponsive."
+
+  program_text = <<-EOF
+    data("vcenter.cluster.memory.effective").publish(label="The effective memory of the cluster. This value excludes memory from hosts in maintenance mode or are unresponsive.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_cluster_memory_used" {
+  name = "The memory that is currently used by the cluster."
+
+  program_text = <<-EOF
+    data("vcenter.cluster.memory.used").publish(label="The memory that is currently used by the cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_cluster_vm_count" {
+  name = "the number of virtual machines in the cluster."
+
+  program_text = <<-EOF
+    data("vcenter.cluster.vm.count").publish(label="the number of virtual machines in the cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_cluster_host_count" {
+  name = "The number of hosts in the cluster."
+
+  program_text = <<-EOF
+    data("vcenter.cluster.host.count").publish(label="The number of hosts in the cluster.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_datastore_disk_usage" {
+  name = "The amount of space in the datastore."
+
+  program_text = <<-EOF
+    data("vcenter.datastore.disk.usage").publish(label="The amount of space in the datastore.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_datastore_disk_utilization" {
+  name = "The utilization of the datastore."
+
+  program_text = <<-EOF
+    data("vcenter.datastore.disk.utilization").publish(label="The utilization of the datastore.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_cpu_utilization" {
+  name = "The CPU utilization of the host system."
+
+  program_text = <<-EOF
+    data("vcenter.host.cpu.utilization").publish(label="The CPU utilization of the host system.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_cpu_usage" {
+  name = "The amount of CPU used by the host."
+
+  program_text = <<-EOF
+    data("vcenter.host.cpu.usage").publish(label="The amount of CPU used by the host.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_disk_throughput" {
+  name = "Average number of kilobytes read from or written to the disk each second."
+
+  program_text = <<-EOF
+    data("vcenter.host.disk.throughput").publish(label="Average number of kilobytes read from or written to the disk each second.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_disk_latency_avg" {
+  name = "The latency of operations to the host system's disk."
+
+  program_text = <<-EOF
+    data("vcenter.host.disk.latency.avg").publish(label="The latency of operations to the host system's disk.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_disk_latency_max" {
+  name = "Highest latency value across all disks used by the host."
+
+  program_text = <<-EOF
+    data("vcenter.host.disk.latency.max").publish(label="Highest latency value across all disks used by the host.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_memory_utilization" {
+  name = "The percentage of the host system's memory capacity that is being utilized."
+
+  program_text = <<-EOF
+    data("vcenter.host.memory.utilization").publish(label="The percentage of the host system's memory capacity that is being utilized.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_memory_usage" {
+  name = "The amount of memory the host system is using."
+
+  program_text = <<-EOF
+    data("vcenter.host.memory.usage").publish(label="The amount of memory the host system is using.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_network_throughput" {
+  name = "The amount of data that was transmitted or received over the network by the host."
+
+  program_text = <<-EOF
+    data("vcenter.host.network.throughput").publish(label="The amount of data that was transmitted or received over the network by the host.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_network_usage" {
+  name = "The sum of the data transmitted and received for all the NIC instances of the host."
+
+  program_text = <<-EOF
+    data("vcenter.host.network.usage").publish(label="The sum of the data transmitted and received for all the NIC instances of the host.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_network_packet_errors" {
+  name = "The summation of packet errors on the host network."
+
+  program_text = <<-EOF
+    data("vcenter.host.network.packet.errors").publish(label="The summation of packet errors on the host network.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_host_network_packet_count" {
+  name = "The number of packets transmitted and received, as measured over the most recent 20s interval."
+
+  program_text = <<-EOF
+    data("vcenter.host.network.packet.count").publish(label="The number of packets transmitted and received, as measured over the most recent 20s interval.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_resource_pool_memory_usage" {
+  name = "The usage of the memory by the resource pool."
+
+  program_text = <<-EOF
+    data("vcenter.resource_pool.memory.usage").publish(label="The usage of the memory by the resource pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_resource_pool_memory_shares" {
+  name = "The amount of shares of memory in the resource pool."
+
+  program_text = <<-EOF
+    data("vcenter.resource_pool.memory.shares").publish(label="The amount of shares of memory in the resource pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_resource_pool_cpu_usage" {
+  name = "The usage of the CPU used by the resource pool."
+
+  program_text = <<-EOF
+    data("vcenter.resource_pool.cpu.usage").publish(label="The usage of the CPU used by the resource pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_resource_pool_cpu_shares" {
+  name = "The amount of shares of CPU in the resource pool."
+
+  program_text = <<-EOF
+    data("vcenter.resource_pool.cpu.shares").publish(label="The amount of shares of CPU in the resource pool.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_memory_ballooned" {
+  name = "The amount of memory that is ballooned due to virtualization."
+
+  program_text = <<-EOF
+    data("vcenter.vm.memory.ballooned").publish(label="The amount of memory that is ballooned due to virtualization.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_memory_usage" {
+  name = "The amount of memory that is used by the virtual machine."
+
+  program_text = <<-EOF
+    data("vcenter.vm.memory.usage").publish(label="The amount of memory that is used by the virtual machine.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_memory_swapped" {
+  name = "The portion of memory that is granted to this VM from the host's swap space."
+
+  program_text = <<-EOF
+    data("vcenter.vm.memory.swapped").publish(label="The portion of memory that is granted to this VM from the host's swap space.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_memory_swapped_ssd" {
+  name = "The amount of memory swapped to fast disk device such as SSD."
+
+  program_text = <<-EOF
+    data("vcenter.vm.memory.swapped_ssd").publish(label="The amount of memory swapped to fast disk device such as SSD.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_disk_usage" {
+  name = "The amount of storage space used by the virtual machine."
+
+  program_text = <<-EOF
+    data("vcenter.vm.disk.usage").publish(label="The amount of storage space used by the virtual machine.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_disk_utilization" {
+  name = "The utilization of storage on the virtual machine."
+
+  program_text = <<-EOF
+    data("vcenter.vm.disk.utilization").publish(label="The utilization of storage on the virtual machine.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_disk_latency_avg" {
+  name = "The latency of operations to the virtual machine's disk."
+
+  program_text = <<-EOF
+    data("vcenter.vm.disk.latency.avg").publish(label="The latency of operations to the virtual machine's disk.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_disk_latency_max" {
+  name = "The highest reported total latency (device and kernel times) over an interval of 20 seconds."
+
+  program_text = <<-EOF
+    data("vcenter.vm.disk.latency.max").publish(label="The highest reported total latency (device and kernel times) over an interval of 20 seconds.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_disk_throughput" {
+  name = "The throughput of the virtual machine's disk."
+
+  program_text = <<-EOF
+    data("vcenter.vm.disk.throughput").publish(label="The throughput of the virtual machine's disk.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_network_throughput" {
+  name = "The amount of data that was transmitted or received over the network of the virtual machine."
+
+  program_text = <<-EOF
+    data("vcenter.vm.network.throughput").publish(label="The amount of data that was transmitted or received over the network of the virtual machine.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_network_packet_count" {
+  name = "The amount of packets that was received or transmitted over the instance's network."
+
+  program_text = <<-EOF
+    data("vcenter.vm.network.packet.count").publish(label="The amount of packets that was received or transmitted over the instance's network.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_network_usage" {
+  name = "The network utilization combined transmit and receive rates during an interval."
+
+  program_text = <<-EOF
+    data("vcenter.vm.network.usage").publish(label="The network utilization combined transmit and receive rates during an interval.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_cpu_utilization" {
+  name = "The CPU utilization of the VM."
+
+  program_text = <<-EOF
+    data("vcenter.vm.cpu.utilization").publish(label="The CPU utilization of the VM.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_cpu_usage" {
+  name = "The amount of CPU used by the VM."
+
+  program_text = <<-EOF
+    data("vcenter.vm.cpu.usage").publish(label="The amount of CPU used by the VM.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "vcenter_vm_memory_utilization" {
+  name = "The memory utilization of the VM."
+
+  program_text = <<-EOF
+    data("vcenter.vm.memory.utilization").publish(label="The memory utilization of the VM.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/zookeeperreceiver_metadata.yaml.tf
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/observability-tf-configs/zookeeperreceiver_metadata.yaml.tf
@@ -1,0 +1,242 @@
+
+resource "signalfx_dashboard" "zookeeperdashboard" {
+  name            = "zookeeper"
+  dashboard_group = signalfx_dashboard_group.zookeeperdashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {
+    chart_ids = [
+      signalfx_time_chart.zookeeper_follower_count.id, signalfx_time_chart.zookeeper_sync_pending.id, signalfx_time_chart.zookeeper_latency_avg.id, signalfx_time_chart.zookeeper_latency_max.id, signalfx_time_chart.zookeeper_latency_min.id, signalfx_time_chart.zookeeper_connection_active.id, signalfx_time_chart.zookeeper_request_active.id, signalfx_time_chart.zookeeper_znode_count.id, signalfx_time_chart.zookeeper_watch_count.id, signalfx_time_chart.zookeeper_data_tree_ephemeral_node_count.id, signalfx_time_chart.zookeeper_data_tree_size.id, signalfx_time_chart.zookeeper_file_descriptor_open.id, signalfx_time_chart.zookeeper_file_descriptor_limit.id, signalfx_time_chart.zookeeper_packet_count.id, signalfx_time_chart.zookeeper_fsync_exceeded_threshold_count.id, signalfx_time_chart.zookeeper_ruok.id
+    ]
+    width  = 4
+    height = 1
+  }
+}
+
+resource "signalfx_dashboard_group" "zookeeperdashboardgroup0" {
+  name        = "zookeeper generated OTel dashboard group"
+  description = "zookeeper generated OTel dashboard group"
+}
+
+resource "signalfx_time_chart" "zookeeper_follower_count" {
+  name = "The number of followers. Only exposed by the leader."
+
+  program_text = <<-EOF
+    data("zookeeper.follower.count").publish(label="The number of followers. Only exposed by the leader.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_sync_pending" {
+  name = "The number of pending syncs from the followers. Only exposed by the leader."
+
+  program_text = <<-EOF
+    data("zookeeper.sync.pending").publish(label="The number of pending syncs from the followers. Only exposed by the leader.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_latency_avg" {
+  name = "Average time in milliseconds for requests to be processed."
+
+  program_text = <<-EOF
+    data("zookeeper.latency.avg").publish(label="Average time in milliseconds for requests to be processed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_latency_max" {
+  name = "Maximum time in milliseconds for requests to be processed."
+
+  program_text = <<-EOF
+    data("zookeeper.latency.max").publish(label="Maximum time in milliseconds for requests to be processed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_latency_min" {
+  name = "Minimum time in milliseconds for requests to be processed."
+
+  program_text = <<-EOF
+    data("zookeeper.latency.min").publish(label="Minimum time in milliseconds for requests to be processed.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_connection_active" {
+  name = "Number of active clients connected to a ZooKeeper server."
+
+  program_text = <<-EOF
+    data("zookeeper.connection.active").publish(label="Number of active clients connected to a ZooKeeper server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_request_active" {
+  name = "Number of currently executing requests."
+
+  program_text = <<-EOF
+    data("zookeeper.request.active").publish(label="Number of currently executing requests.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_znode_count" {
+  name = "Number of z-nodes that a ZooKeeper server has in its data tree."
+
+  program_text = <<-EOF
+    data("zookeeper.znode.count").publish(label="Number of z-nodes that a ZooKeeper server has in its data tree.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_watch_count" {
+  name = "Number of watches placed on Z-Nodes on a ZooKeeper server."
+
+  program_text = <<-EOF
+    data("zookeeper.watch.count").publish(label="Number of watches placed on Z-Nodes on a ZooKeeper server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_data_tree_ephemeral_node_count" {
+  name = "Number of ephemeral nodes that a ZooKeeper server has in its data tree."
+
+  program_text = <<-EOF
+    data("zookeeper.data_tree.ephemeral_node.count").publish(label="Number of ephemeral nodes that a ZooKeeper server has in its data tree.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_data_tree_size" {
+  name = "Size of data in bytes that a ZooKeeper server has in its data tree."
+
+  program_text = <<-EOF
+    data("zookeeper.data_tree.size").publish(label="Size of data in bytes that a ZooKeeper server has in its data tree.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_file_descriptor_open" {
+  name = "Number of file descriptors that a ZooKeeper server has open."
+
+  program_text = <<-EOF
+    data("zookeeper.file_descriptor.open").publish(label="Number of file descriptors that a ZooKeeper server has open.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_file_descriptor_limit" {
+  name = "Maximum number of file descriptors that a ZooKeeper server can open."
+
+  program_text = <<-EOF
+    data("zookeeper.file_descriptor.limit").publish(label="Maximum number of file descriptors that a ZooKeeper server can open.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_packet_count" {
+  name = "The number of ZooKeeper packets received or sent by a server."
+
+  program_text = <<-EOF
+    data("zookeeper.packet.count").publish(label="The number of ZooKeeper packets received or sent by a server.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_fsync_exceeded_threshold_count" {
+  name = "Number of times fsync duration has exceeded warning threshold."
+
+  program_text = <<-EOF
+    data("zookeeper.fsync.exceeded_threshold.count").publish(label="Number of times fsync duration has exceeded warning threshold.")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}
+
+
+resource "signalfx_time_chart" "zookeeper_ruok" {
+  name = "Response from zookeeper ruok command"
+
+  program_text = <<-EOF
+    data("zookeeper.ruok").publish(label="Response from zookeeper ruok command")
+  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-dashboard-o11y.py
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-dashboard-o11y.py
@@ -99,7 +99,7 @@ def process_yaml_file(file_path):
 
 # Run the thing
 if args.file_path == "":
-  directory = "./otel-receiver-configs"
+  directory = "./otel-receiver-yaml"
   for filename in os.listdir(directory):
       f = os.path.join(directory, filename)
       # checking if it is a file

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-dashboard-o11y.py
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-dashboard-o11y.py
@@ -1,0 +1,118 @@
+import yaml
+import argparse
+import os
+
+parser = argparse.ArgumentParser(description="Generates Terraform configs for Splunk Observability dashboards from OpenTelemetry receiver metadata YAML files that contain the receiver's metrics")
+parser.add_argument('--file_path', metavar='file_path', type=str, default="", help='Path to an OpenTelemetry receiver YAML file containing metrics. Generated config printed to STDOUT')
+
+args = parser.parse_args()
+
+def create_shart_resources(metrics):
+    """Creat chart resources from provided dict of metrics from the provided yaml
+
+    Returns:
+    terraform_chart_configs -- contains chart resource configurations
+    """
+
+    terraform_chart_configs = []
+    for index, (metric_name, metric_details) in enumerate(metrics.items()):
+        program_text = f'data("{metric_name}").publish(label="{metric_details["description"]}")\n'
+        chart_name = metric_name.replace(".", "_").replace("-", "_")
+        chart_config = f'''
+resource "signalfx_time_chart" "{chart_name}" {{
+  name = "{metric_details["description"]}"
+
+  program_text = <<-EOF
+    {program_text}  EOF
+
+  time_range = 14400
+
+  plot_type         = "LineChart"
+  show_data_markers = true
+}}
+'''
+        terraform_chart_configs.append(chart_config)
+        
+        chart_block = f'''chart {{
+  chart_id = signalfx_time_chart.{chart_name}.id
+}}'''    
+
+    return terraform_chart_configs
+
+def create_dashboard_resources(metrics, type):
+    """Creates the dashboard and dashboard group resources from provided 
+    dicts of metrics and type pulled from yaml.
+
+    Returns:
+    dashboard_config -- contains the dashboard and dashboard group TF configs
+    """
+
+    dashboard_config = f'''
+resource "signalfx_dashboard" "{type}dashboard" {{
+  name            = "{type}"
+  dashboard_group = signalfx_dashboard_group.{type}dashboardgroup0.id
+  time_range      = "-1h"
+
+  grid {{
+    chart_ids = [
+      {", ".join([f'signalfx_time_chart.{metric_name.replace(".", "_").replace("-", "_")}.id' for metric_name in metrics.keys()])}
+    ]
+    width  = 4
+    height = 1
+  }}
+}}
+
+resource "signalfx_dashboard_group" "{type}dashboardgroup0" {{
+  name        = "{type} generated OTel dashboard group"
+  description = "{type} generated OTel dashboard group"
+}}
+'''
+    return dashboard_config
+                
+def process_yaml_file(file_path):
+    """Opens a metadata.yaml file from an OpenTelemetry Receiver that defines
+    receiver metrics as input. Generates an appropriate signalfx Terraform 
+    configuration from the provided input and prints it to stdout.
+    """
+    try:
+        with open(file_path, 'r') as file:
+            yaml_content = file.read()
+            data = yaml.safe_load(yaml_content)
+
+            # Get dicts from the loaded yaml
+            metrics = data.get("metrics", {})
+            type = data.get("type", str)
+
+            # Generate chart resources for each metric
+            terraform_chart_configs = create_shart_resources(metrics)
+
+            # Join Terraform configurations into a single string
+            terraform_chart_str = "\n".join(terraform_chart_configs)
+
+        dashboard_config = create_dashboard_resources(metrics, type)
+        return terraform_chart_str, dashboard_config
+    except FileNotFoundError:
+        print(f"Error: File '{file_path}' not found at the provided path. Please provide the path to an OTEL Receiver metadata.yaml file which contains that receivers metrics and attributes")
+    except Exception as e:
+        print(f"Error: {e}. Please use `--file_path` provide the path to an OTEL Receiver metadata.yaml file which contains that receivers metrics and attributes")
+
+
+# Run the thing
+if args.file_path == "":
+  directory = "./otel-receiver-configs"
+  for filename in os.listdir(directory):
+      f = os.path.join(directory, filename)
+      # checking if it is a file
+      if os.path.isfile(f):
+          print(f)
+          terraform_chart_str, dashboard_config = process_yaml_file(f)
+          configname = f"./observability-tf-configs/{filename}.tf"
+          with open(configname, "w", encoding="utf-8") as file:
+              file.write(dashboard_config)
+              file.write(terraform_chart_str)
+          print(f"Created Observability Terraform config for {filename}")
+else:
+    terraform_chart_str, dashboard_config = process_yaml_file(args.file_path)
+    print(terraform_chart_str)
+    print(dashboard_config)
+

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/activedirectorydsreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/activedirectorydsreceiver_metadata.yaml
@@ -1,0 +1,210 @@
+type: active_directory_ds
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski, BinaryFissionGames]
+
+attributes:
+  direction:
+    description: The direction of data flow.
+    type: string
+    enum:
+      - sent
+      - received
+  network_data_type:
+    name_override: type
+    description: The type of network data sent.
+    type: string
+    enum:
+      - compressed
+      - uncompressed
+  value_type:
+    name_override: type
+    description: The type of value sent.
+    type: string
+    enum:
+      - distingushed_names
+      - other
+  operation_type:
+    name_override: type
+    description: The type of operation.
+    type: string
+    enum:
+      - read
+      - write
+      - search
+  suboperation_type:
+    name_override: type
+    description: The type of suboperation.
+    type: string
+    enum:
+      - security_descriptor_propagations_event
+      - search
+  sync_result:
+    name_override: result
+    description: The result status of the sync request.
+    type: string
+    enum:
+      - success
+      - schema_mismatch
+      - other
+  bind_type:
+    name_override: type
+    description: The type of bind to the domain server.
+    type: string
+    enum:
+      - server
+      - client
+metrics:
+  active_directory.ds.replication.network.io:
+    description: "The amount of network data transmitted by the Directory Replication Agent."
+    unit: By
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [direction, network_data_type]
+    enabled: true
+  active_directory.ds.replication.sync.object.pending:
+    description: "The number of objects remaining until the full sync completes for the Directory Replication Agent."
+    unit: "{objects}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  active_directory.ds.replication.sync.request.count:
+    description: "The number of sync requests made by the Directory Replication Agent."
+    unit: "{requests}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [sync_result]
+    enabled: true
+  active_directory.ds.replication.object.rate:
+    description: "The number of objects transmitted by the Directory Replication Agent per second."
+    unit: "{objects}/s"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: double
+    attributes: [direction]
+    enabled: true
+  active_directory.ds.replication.property.rate:
+    description: "The number of properties transmitted by the Directory Replication Agent per second."
+    unit: "{properties}/s"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: double
+    attributes: [direction]
+    enabled: true
+  active_directory.ds.replication.value.rate:
+    description: "The number of values transmitted by the Directory Replication Agent per second."
+    unit: "{values}/s"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: double
+    attributes: [direction, value_type]
+    enabled: true
+  active_directory.ds.replication.operation.pending:
+    description: "The number of pending replication operations for the Directory Replication Agent."
+    unit: "{operations}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  active_directory.ds.operation.rate:
+    description: "The number of operations performed per second."
+    unit: "{operations}/s"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: double
+    attributes: [operation_type]
+    enabled: true
+  active_directory.ds.name_cache.hit_rate:
+    description: "The percentage of directory object name component lookups that are satisfied by the Directory System Agent's name cache."
+    unit: "%"
+    gauge:
+      value_type: double
+    enabled: true
+  active_directory.ds.notification.queued:
+    description: "The number of pending update notifications that have been queued to push to clients."
+    unit: "{notifications}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  active_directory.ds.security_descriptor_propagations_event.queued:
+    description: "The number of security descriptor propagation events that are queued for processing."
+    unit: "{events}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  active_directory.ds.suboperation.rate:
+    description: "The rate of sub-operations performed."
+    unit: "{suboperations}/s"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: double
+    attributes: [suboperation_type]
+    enabled: true
+  active_directory.ds.bind.rate:
+    description: "The number of binds per second serviced by this domain controller."
+    unit: "{binds}/s"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: double
+    attributes: [bind_type]
+    enabled: true
+  active_directory.ds.thread.count:
+    description: "The number of threads in use by the directory service."
+    unit: "{threads}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  active_directory.ds.ldap.client.session.count:
+    description: "The number of connected LDAP client sessions."
+    unit: "{sessions}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  active_directory.ds.ldap.bind.last_successful.time:
+    description: "The amount of time taken for the last successful LDAP bind."
+    unit: "ms"
+    gauge:
+      value_type: int
+    enabled: true
+  active_directory.ds.ldap.bind.rate:
+    description: "The number of successful LDAP binds per second."
+    unit: "{binds}/s"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: double
+    enabled: true
+  active_directory.ds.ldap.search.rate:
+    description: "The number of LDAP searches per second."
+    unit: "{searches}/s"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: double
+    enabled: true

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/aerospikereceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/aerospikereceiver_metadata.yaml
@@ -1,0 +1,250 @@
+type: aerospike
+
+status:
+  class: receiver
+  stability:
+    alpha: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski, antonblock]
+
+resource_attributes:
+  aerospike.node.name:
+    description: Name of the Aerospike node collected from
+    enabled: true
+    type: string
+  aerospike.namespace:
+    description: Name of the Aerospike namespace
+    enabled: true
+    type: string
+
+attributes:
+  namespace_component:
+    name_override: component
+    description: Individual component of a namespace
+    type: string
+    enum:
+      - data
+      - index
+      - set_index
+      - secondary_index
+  scan_type:
+    name_override: type
+    description: Type of scan operation performed on a namespace
+    type: string
+    enum:
+      - aggregation
+      - basic
+      - ops_background
+      - udf_background
+  scan_result:
+    name_override: result
+    description: Result of a scan operation performed on a namespace
+    type: string
+    enum:
+      - abort
+      - complete
+      - error
+  index_type:
+    name_override: index
+    description: Type of index the operation was performed on
+    type: string
+    enum:
+      - primary
+      - secondary
+  query_type:
+    name_override: type
+    description: Type of query operation performed on a namespace
+    type: string
+    enum:
+      - aggregation
+      - basic
+      - short
+      - long_basic
+      - short_basic
+      - ops_background
+      - udf_background
+  query_result:
+    name_override: result
+    description: Result of a query operation performed on a namespace
+    type: string
+    enum:
+      - abort
+      - complete
+      - error
+      - timeout # short_basic queries only
+  transaction_type:
+    name_override: type
+    description: Type of transaction performed on a namespace
+    type: string
+    enum:
+      - delete
+      - read
+      - udf
+      - write
+  transaction_result:
+    name_override: result
+    description: Result of a transaction performed on a namespace
+    type: string
+    enum:
+      - error
+      - filtered_out
+      - not_found
+      - success
+      - timeout
+  connection_type:
+    name_override: type
+    description: Type of connection to an Aerospike node
+    type: string
+    enum:
+      - client
+      - fabric
+      - heartbeat
+  connection_op:
+    name_override: operation
+    description: Operation performed with a connection (open or close)
+    type: string
+    enum:
+      - close
+      - open
+
+metrics:
+  aerospike.node.memory.free:
+    enabled: true
+    description: Percentage of the node's memory which is still free
+    extended_documentation: Aerospike Metric system_free_mem_pct
+    unit: '%'
+    gauge:
+      value_type: int
+      input_type: string
+  aerospike.node.connection.count:
+    enabled: true
+    description: Number of connections opened and closed to the node
+    extended_documentation: Aggregate of Aerospike Metrics client_connections_closed, client_connections_opened, fabric_connections_closed, fabric_connections_opened, heartbeat_connections_closed, heartbeat_connections_opened
+    unit: '{connections}'
+    attributes: [connection_type, connection_op]
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  aerospike.node.connection.open:
+    enabled: true
+    description: Current number of open connections to the node
+    extended_documentation: Aggregate of Aerospike Metrics client_connections, fabric_connections, heartbeat_connections
+    unit: '{connections}'
+    attributes: [connection_type]
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
+  aerospike.node.query.tracked:
+    enabled: true
+    description: Number of queries tracked by the system.
+    extended_documentation: Number of queries which ran more than query untracked_time (default 1 sec), Aerospike metric query_tracked
+    unit: '{queries}'
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  aerospike.namespace.memory.usage:
+    enabled: true
+    description: Memory currently used by each component of the namespace
+    extended_documentation: Aggregate of Aerospike Metrics memory_used_data_bytes, memory_used_index_bytes, memory_used_set_index_bytes, memory_used_sindex_bytes
+    unit: By
+    attributes: [namespace_component]
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
+  aerospike.namespace.memory.free:
+    enabled: true
+    description: Percentage of the namespace's memory which is still free
+    extended_documentation: Aerospike metric memory_free_pct
+    unit: '%'
+    gauge:
+      value_type: int
+      input_type: string
+  aerospike.namespace.disk.available:
+    enabled: true
+    description: Minimum percentage of contiguous disk space free to the namespace across all devices
+    unit: '%'
+    gauge:
+      value_type: int
+      input_type: string
+  aerospike.namespace.scan.count:
+    enabled: true
+    description: Number of scan operations performed on the namespace
+    unit: '{scans}'
+    extended_documentation: Aggregate of Aerospike Metrics scan_aggr_abort, scan_aggr_complete, scan_aggr_error, scan_basic_abort, scan_basic_complete, scan_basic_error, scan_ops_bg_abort, scan_ops_bg_complete, scan_ops_bg_error, scan_udf_bg_abort, scan_udf_bg_complete, scan_udf_bg_error
+    attributes: [scan_type, scan_result]
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  aerospike.namespace.query.count:
+    enabled: true
+    description: Number of query operations performed on the namespace
+    unit: '{queries}'
+    extended_documentation: Aggregate of Aerospike Metrics query_aggr_abort, query_aggr_complete, query_aggr_error, query_basic_abort, query_basic_complete, query_basic_error, query_ops_bg_abort, query_ops_bg_complete, query_ops_bg_error, query_udf_bg_abort, query_udf_bg_complete, query_udf_bg_error, pi_query_aggr_abort, pi_query_aggr_complete, pi_query_aggr_error, pi_query_long_basic_abort, pi_query_long_basic_complete, pi_query_long_basic_error, pi_query_ops_bg_abort, pi_query_ops_bg_basic_complete, pi_query_ops_bg_basic_error, pi_query_short_basic_timeout, pi_query_short_basic_complete, pi_query_short_basic_error, pi_query_udf_bg_abort, pi_query_udf_bg_complete, pi_query_udf_bg_error, si_query_aggr_abort, si_query_aggr_complete, si_query_aggr_error, si_query_long_basic_abort, si_query_long_basic_complete, si_query_long_basic_error, si_query_ops_bg_abort, si_query_ops_bg_basic_complete, si_query_ops_bg_basic_error, si_query_short_basic_timeout, si_query_short_basic_complete, si_query_short_basic_error, si_query_udf_bg_abort, si_query_udf_bg_complete, si_query_udf_bg_error
+    attributes: [query_type, index_type, query_result]
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  aerospike.namespace.geojson.region_query_cells:
+    enabled: true
+    description: Number of cell coverings for query region queried
+    unit: '{cells}'
+    extended_documentation: Number of cell coverings for query region queried. Aerospike metric geo_region_query_cells.
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  aerospike.namespace.geojson.region_query_false_positive:
+    enabled: true
+    description: Number of points outside the region.
+    unit: '{points}'
+    extended_documentation: Total query result points is geo_region_query_points + geo_region_query_falsepos. Aerospike metric geo_regio_query_falspos.
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  aerospike.namespace.geojson.region_query_points:
+    enabled: true
+    description: Number of points within the region.
+    unit: '{points}'
+    extended_documentation: Total query result points is geo_region_query_points + geo_region_query_falsepos. Aerospike metric geo_region_query_points.
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  aerospike.namespace.geojson.region_query_requests:
+    enabled: true
+    description: Number of geojson queries on the system since the uptime of the node.
+    unit: '{queries}'
+    extended_documentation: Number of geojson queries on the system since the uptime of the node. Aerospike metric geo_region_query_reqs.
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  aerospike.namespace.transaction.count:
+    enabled: true
+    description: Number of transactions performed on the namespace
+    unit: '{transactions}'
+    extended_documentation: Aggregate of Aerospike Metrics client_delete_error, client_delete_filtered_out, client_delete_not_found, client_delete_success, client_delete_timeout, client_read_error, client_read_filtered_out, client_read_not_found, client_read_success, client_read_timeout, client_udf_error, client_udf_filtered_out, client_udf_not_found, client_udf_success, client_udf_timeout, client_write_error, client_write_filtered_out, client_write_not_found, client_write_success, client_write_timeout
+    attributes: [transaction_type, transaction_result]
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/apachereceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/apachereceiver_metadata.yaml
@@ -1,0 +1,175 @@
+type: apache
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski]
+
+resource_attributes:
+    apache.server.name:
+      description: The name of the Apache HTTP server.
+      type: string
+      enabled: true
+    apache.server.port:
+      description: The port of the Apache HTTP server.
+      type: string
+      enabled: true
+
+attributes:
+  workers_state:
+    name_override: state
+    description: The state of workers.
+    type: string
+    enum:
+      - busy
+      - idle
+  cpu_level:
+    name_override: level
+    description: Level of processes.
+    type: string
+    enum:
+      - self
+      - children
+  cpu_mode:
+    name_override: mode
+    description: Mode of processes.
+    type: string
+    enum:
+    - system
+    - user
+  scoreboard_state:
+    name_override: state
+    description: The state of a connection.
+    type: string
+    enum:
+      - open
+      - waiting
+      - starting
+      - reading
+      - sending
+      - keepalive
+      - dnslookup
+      - closing
+      - logging
+      - finishing
+      - idle_cleanup
+      - unknown
+
+metrics:
+  apache.uptime:
+    enabled: true
+    description: The amount of time that the server has been running in seconds.
+    unit: s
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  apache.current_connections:
+    enabled: true
+    description: The number of active connections currently attached to the HTTP server.
+    unit: "{connections}"
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: []
+  apache.workers:
+    enabled: true
+    description: The number of workers currently attached to the HTTP server.
+    unit: "{workers}"
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [workers_state]
+  apache.requests:
+    enabled: true
+    description: The number of requests serviced by the HTTP server per second.
+    unit: "{requests}"
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  apache.traffic:
+    enabled: true
+    description: Total HTTP server traffic.
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  apache.cpu.time:
+    enabled: true
+    description: Jiffs used by processes of given category.
+    unit: "{jiff}"
+    sum:
+      value_type: double
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [cpu_level, cpu_mode]
+  apache.cpu.load:
+    enabled: true
+    description: Current load of the CPU.
+    unit: "%"
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: []
+  apache.load.1:
+    enabled: true
+    description: The average server load during the last minute.
+    unit: "%"
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: []
+  apache.load.5:
+    enabled: true
+    description: The average server load during the last 5 minutes.
+    unit: "%"
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: []
+  apache.load.15:
+    enabled: true
+    description: The average server load during the last 15 minutes.
+    unit: "%"
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: []
+  apache.request.time:
+    enabled: true
+    description: Total time spent on handling requests.
+    unit: ms
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  apache.scoreboard:
+    enabled: true
+    description: The number of workers in each state.
+    extended_documentation: >-
+      The apache scoreboard is an encoded representation of the state of all the server's workers.
+      This metric decodes the scoreboard and presents a count of workers in each state.
+      Additional details can be found [here](https://metacpan.org/pod/Apache::Scoreboard#DESCRIPTION).
+    unit: "{workers}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [scoreboard_state]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/apachesparkreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/apachesparkreceiver_metadata.yaml
@@ -1,0 +1,690 @@
+type: apachespark
+
+status:
+  class: receiver
+  stability: 
+    development: [metrics]
+  distributions: [contrib]
+  codeowners:
+    active: [djaglowski, Caleb-Hurshman, mrsillydog]
+
+resource_attributes:
+  spark.application.id:
+    description: The ID of the application for which the metric was recorded.
+    type: string
+    enabled: true
+  spark.application.name:
+    description: The name of the application for which the metric was recorded.
+    type: string
+    enabled: true
+  spark.stage.id:
+    description: The ID of the application stage for which the metric was recorded.
+    type: int
+    enabled: true
+  spark.stage.attempt.id:
+    description: The ID of the stage attempt for which the metric was recorded.
+    type: int
+  spark.executor.id:
+    description: The ID of the executor for which the metric was recorded.
+    type: string
+    enabled: true
+  spark.job.id:
+    description: The ID of the job for which the metric was recorded.
+    type: int
+    enabled: true
+
+attributes:
+  stage_active:
+    name_override: active
+    description: Whether the stage for which the metric was recorded is active.
+    type: bool
+  stage_complete:
+    name_override: complete
+    description: Whether the stage for which the metric was recorded is complete.
+    type: bool
+  stage_pending:
+    name_override: pending
+    description: Whether the stage for which the metric was recorded is pending.
+    type: bool
+  stage_failed:
+    name_override: failed
+    description: Whether the stage for which the metric was recorded is failed.
+    type: bool
+  stage_task_result:
+    name_override: result
+    description: The result of the stage tasks for which the metric was recorded.
+    type: string
+    enum:
+      - completed
+      - failed
+      - killed
+  executor_task_result:
+    name_override: result
+    description: The result of the executor tasks for which the metric was recorded.
+    type: string
+    enum:
+      - completed
+      - failed
+  job_result:
+    name_override: result
+    description: The result of the job stages or tasks for which the metric was recorded.
+    type: string
+    enum:
+      - completed
+      - failed
+      - skipped
+  direction:
+    description: Whether the metric is in regards to input or output operations.
+    type: string
+    enum:
+      - in
+      - out
+  source:
+    description: The source from which data was fetched for the metric.
+    type: string
+    enum:
+      - local
+      - remote
+  location:
+    description: The location of the memory for which the metric was recorded..
+    type: string
+    enum:
+      - on_heap
+      - off_heap
+  state:
+    description: The state of the memory for which the metric was recorded.
+    type: string
+    enum:
+      - used
+      - free
+  scheduler_status:
+    name_override: status
+    description: The status of the DAGScheduler stages for which the metric was recorded.
+    type: string
+    enum:
+      - waiting
+      - running
+  pool_memory_type:
+    name_override: type
+    description: The type of pool memory for which the metric was recorded.
+    type: string
+    enum:
+      - direct
+      - mapped
+  gc_type:
+    description: The type of the garbage collection performed for the metric.
+    type: string
+    enum:
+      - major
+      - minor
+
+metrics:
+  #stage
+  spark.stage.status:
+    description: A one-hot encoding representing the status of this stage.
+    enabled: true
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    unit: "{ status }"
+    attributes:
+      [stage_active, stage_complete, stage_pending, stage_failed]
+  spark.stage.task.active:
+    description: Number of active tasks in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{ task }"
+    attributes: []
+  spark.stage.task.result:
+    description: Number of tasks with a specific result in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ task }"
+    attributes:
+      [stage_task_result]
+  spark.stage.executor.run_time:
+    description: Amount of time spent by the executor in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: ms
+    attributes: []
+  spark.stage.executor.cpu_time:
+    description: CPU time spent by the executor in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: ns
+    attributes: []
+  spark.stage.task.result_size:
+    description: The amount of data transmitted back to the driver by all the tasks in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: bytes
+    attributes: []
+  spark.stage.jvm_gc_time:
+    description: The amount of time the JVM spent on garbage collection in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: ms
+    attributes: []
+  spark.stage.memory.spilled:
+    description: The amount of memory moved to disk due to size constraints (spilled) in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: bytes
+    attributes: []
+  spark.stage.disk.spilled:
+    description: The amount of disk space used for storing portions of overly large data chunks that couldn't fit in memory in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: bytes
+    attributes: []
+  spark.stage.memory.peak:
+    description: Peak memory used by internal data structures created during shuffles, aggregations and joins in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: bytes
+    attributes: []
+  spark.stage.io.size:
+    description: Amount of data written and read at this stage.
+    enabled: true
+    sum: 
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: bytes
+    attributes:
+      [direction]
+  spark.stage.io.records:
+    description: Number of records written and read in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ record }"
+    attributes:
+      [direction]
+  spark.stage.shuffle.blocks_fetched:
+    description: Number of blocks fetched in shuffle operations in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ block }"
+    attributes:
+      [source]
+  spark.stage.shuffle.fetch_wait_time:
+    description: Time spent in this stage waiting for remote shuffle blocks.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: ms
+    attributes: []
+  spark.stage.shuffle.io.disk:
+    description: Amount of data read to disk in shuffle operations (sometimes required for large blocks, as opposed to the default behavior of reading into memory).
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: bytes
+    attributes: []
+  spark.stage.shuffle.io.read.size:
+    description: Amount of data read in shuffle operations in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: bytes
+    attributes:
+      [source]
+  spark.stage.shuffle.io.write.size:
+    description: Amount of data written in shuffle operations in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: bytes
+    attributes:
+      []
+  spark.stage.shuffle.io.records:
+    description: Number of records written or read in shuffle operations in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ record }"
+    attributes:
+      [direction]
+  spark.stage.shuffle.write_time:
+    description: Time spent blocking on writes to disk or buffer cache in this stage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: ns
+    attributes: []
+  #executor
+  spark.executor.memory.usage:
+    description: Storage memory used by this executor.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: bytes
+    attributes: []
+  spark.executor.disk.usage:
+    description: Disk space used by this executor for RDD storage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: bytes
+    attributes: []
+  spark.executor.task.limit:
+    description: Maximum number of tasks that can run concurrently in this executor.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{ task }"
+    attributes: []
+  spark.executor.task.active:
+    description: Number of tasks currently running in this executor.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{ task }"
+    attributes: []
+  spark.executor.task.result:
+    description: Number of tasks with a specific result in this executor.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ task }"
+    attributes: [executor_task_result]
+  spark.executor.time:
+    description: Elapsed time the JVM spent executing tasks in this executor.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: ms
+    attributes: []
+  spark.executor.gc_time:
+    description: Elapsed time the JVM spent in garbage collection in this executor.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: ms
+    attributes: []
+  spark.executor.input_size:
+    description: Amount of data input for this executor.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: bytes
+    attributes: []
+  spark.executor.shuffle.io.size:
+    description: Amount of data written and read during shuffle operations for this executor.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: bytes
+    attributes: [direction]
+  spark.executor.storage_memory.usage:
+    description: The executor's storage memory usage.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: bytes
+    attributes: [location, state]
+  #job
+  spark.job.task.active:
+    description: Number of active tasks in this job.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{ task }"
+    attributes: []
+  spark.job.task.result:
+    description: Number of tasks with a specific result in this job.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ task }"
+    attributes: [job_result]
+  spark.job.stage.active:
+    description: Number of active stages in this job.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{ stage }"
+    attributes: []
+  spark.job.stage.result:
+    description: Number of stages with a specific result in this job.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ stage }"
+    attributes: [job_result]
+  # metrics
+  spark.driver.block_manager.disk.usage:
+    description: Disk space used by the BlockManager.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: mb
+    attributes: []
+  spark.driver.block_manager.memory.usage:
+    description: Memory usage for the driver's BlockManager.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: mb
+    attributes: [location, state]
+  spark.driver.hive_external_catalog.file_cache_hits:
+    description: Number of file cache hits on the HiveExternalCatalog.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ hit }"
+    attributes: []
+  spark.driver.hive_external_catalog.files_discovered:
+    description: Number of files discovered while listing the partitions of a table in the Hive metastore
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ file }"
+    attributes: []
+  spark.driver.hive_external_catalog.hive_client_calls:
+    description: Number of calls to the underlying Hive Metastore client made by the Spark application.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ call }"
+    attributes: []
+  spark.driver.hive_external_catalog.parallel_listing_jobs:
+    description: Number of parallel listing jobs initiated by the HiveExternalCatalog when listing partitions of a table.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ listing_job }"
+    attributes: []
+  spark.driver.hive_external_catalog.partitions_fetched:
+    description: Table partitions fetched by the HiveExternalCatalog.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ partition }"
+    attributes: []
+  spark.driver.code_generator.compilation.count:
+    description: Number of source code compilation operations performed by the CodeGenerator.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ compilation }"
+    attributes: []
+  spark.driver.code_generator.compilation.average_time:
+    description: Average time spent during CodeGenerator source code compilation operations.
+    enabled: true
+    gauge:
+      value_type: double
+    unit: ms
+    attributes: []
+  spark.driver.code_generator.generated_class.count:
+    description: Number of classes generated by the CodeGenerator.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ class }"
+    attributes: []
+  spark.driver.code_generator.generated_class.average_size:
+    description: Average class size of the classes generated by the CodeGenerator.
+    enabled: true
+    gauge:
+      value_type: double
+    unit: bytes
+    attributes: []
+  spark.driver.code_generator.generated_method.count:
+    description: Number of methods generated by the CodeGenerator.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ method }"
+    attributes: []
+  spark.driver.code_generator.generated_method.average_size:
+    description: Average method size of the classes generated by the CodeGenerator.
+    enabled: true
+    gauge:
+      value_type: double
+    unit: bytes
+    attributes: []
+  spark.driver.code_generator.source_code.operations:
+    description: Number of source code generation operations performed by the CodeGenerator.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ operation }"
+    attributes: []
+  spark.driver.code_generator.source_code.average_size:
+    description: Average size of the source code generated by a CodeGenerator code generation operation.
+    enabled: true
+    gauge:
+      value_type: double
+    unit: bytes
+    attributes: []
+  spark.driver.dag_scheduler.job.active:
+    description: Number of active jobs currently being processed by the DAGScheduler.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{ job }"
+    attributes: []
+  spark.driver.dag_scheduler.job.count:
+    description: Number of jobs that have been submitted to the DAGScheduler.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ job }"
+    attributes: []
+  spark.driver.dag_scheduler.stage.failed:
+    description: Number of failed stages run by the DAGScheduler.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ stage }"
+    attributes: []
+  spark.driver.dag_scheduler.stage.count:
+    description: Number of stages the DAGScheduler is either running or needs to run.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{ stage }"
+    attributes: [scheduler_status]
+  spark.driver.live_listener_bus.posted:
+    description: Number of events that have been posted on the LiveListenerBus.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ event }"
+    attributes: []
+  spark.driver.live_listener_bus.processing_time.average:
+    description: Average time taken for the LiveListenerBus to process an event posted to it.
+    enabled: true
+    gauge:
+      value_type: double
+    unit: ms
+    attributes: []
+  spark.driver.live_listener_bus.dropped:
+    description: Number of events that have been dropped by the LiveListenerBus.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ event }"
+    attributes: []
+  spark.driver.live_listener_bus.queue_size:
+    description: Number of events currently waiting to be processed by the LiveListenerBus.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{ event }"
+    attributes: []
+  spark.driver.jvm_cpu_time:
+    description: Current CPU time taken by the Spark driver.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: ns
+    attributes: []
+  spark.driver.executor.memory.jvm:
+    description: Amount of memory used by the driver's JVM.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: bytes
+    attributes: [location]
+  spark.driver.executor.memory.execution:
+    description: Amount of execution memory currently used by the driver.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: bytes
+    attributes: [location]
+  spark.driver.executor.memory.storage:
+    description: Amount of storage memory currently used by the driver.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: bytes
+    attributes: [location]
+  spark.driver.executor.memory.pool:
+    description: Amount of pool memory currently used by the driver.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: bytes
+    attributes: [pool_memory_type]
+  spark.driver.executor.gc.operations:
+    description: Number of garbage collection operations performed by the driver.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{ gc_operation }"
+    attributes: [gc_type]
+  spark.driver.executor.gc.time:
+    description: Total elapsed time during garbage collection operations performed by the driver.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: ms
+    attributes: [gc_type]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/bigipreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/bigipreceiver_metadata.yaml
@@ -1,0 +1,288 @@
+type: bigip
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski, StefanKurek]
+
+resource_attributes:
+  bigip.virtual_server.name:
+    description: The name of the Big-IP Virtual Server.
+    type: string
+    enabled: true
+  bigip.virtual_server.destination:
+    description: The destination for the Big-IP Virtual Server.
+    type: string
+    enabled: true
+  bigip.pool.name:
+    description: The name of the Big-IP Pool.
+    type: string
+    enabled: true
+  bigip.pool_member.name:
+    description: The name of the Big-IP Pool Member.
+    type: string
+    enabled: true
+  bigip.pool_member.ip_address:
+    description: The IP Address of the Big-IP Pool Member.
+    type: string
+    enabled: true
+  bigip.node.name:
+    description: The name of the Big-IP Node.
+    type: string
+    enabled: true
+  bigip.node.ip_address:
+    description: The IP Address of the Big-IP Node.
+    type: string
+    enabled: true
+
+attributes:
+  direction:
+    description: The direction of data.
+    type: string
+    enum:
+      - sent
+      - received
+  availability.status:
+    name_override: status
+    description: The availability status.
+    type: string
+    enum:
+      - offline
+      - unknown
+      - available
+  enabled.status:
+    name_override: status
+    description: The enabled status.
+    type: string
+    enum:
+      - disabled
+      - enabled
+  active.status:
+    name_override: status
+    description: The active status.
+    type: string
+    enum:
+      - active
+      - inactive
+
+metrics:
+  bigip.virtual_server.data.transmitted:
+    description: Amount of data transmitted to and from the virtual server.
+    unit: "By"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [direction]
+    enabled: true
+  bigip.virtual_server.connection.count:
+    description: Current number of connections to the virtual server.
+    unit: "{connections}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  bigip.virtual_server.request.count:
+    description: Number of requests to the virtual server.
+    unit: "{requests}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  bigip.virtual_server.packet.count:
+    description: Number of packets transmitted to and from the virtual server.
+    unit: "{packets}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [direction]
+    enabled: true
+  bigip.virtual_server.availability:
+    description: Availability of the virtual server.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [availability.status]
+    enabled: true
+  bigip.virtual_server.enabled:
+    description: Enabled state of of the virtual server.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [enabled.status]
+    enabled: true
+  bigip.pool.data.transmitted:
+    description: Amount of data transmitted to and from the pool.
+    unit: "By"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [direction]
+    enabled: true
+  bigip.pool.connection.count:
+    description: Current number of connections to the pool.
+    unit: "{connections}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  bigip.pool.request.count:
+    description: Number of requests to the pool.
+    unit: "{requests}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  bigip.pool.packet.count:
+    description: Number of packets transmitted to and from the pool.
+    unit: "{packets}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [direction]
+    enabled: true
+  bigip.pool.member.count:
+    description: Total number of pool members.
+    unit: "{members}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [active.status]
+    enabled: true
+  bigip.pool.availability:
+    description: Availability of the pool.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [availability.status]
+    enabled: true
+  bigip.pool.enabled:
+    description: Enabled state of of the pool.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [enabled.status]
+    enabled: true
+  bigip.pool_member.data.transmitted:
+    description: Amount of data transmitted to and from the pool member.
+    unit: "By"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [direction]
+    enabled: true
+  bigip.pool_member.connection.count:
+    description: Current number of connections to the pool member.
+    unit: "{connections}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  bigip.pool_member.request.count:
+    description: Number of requests to the pool member.
+    unit: "{requests}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  bigip.pool_member.packet.count:
+    description: Number of packets transmitted to and from the pool member.
+    unit: "{packets}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [direction]
+    enabled: true
+  bigip.pool_member.session.count:
+    description: Current number of sessions for the pool member.
+    unit: "{sessions}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  bigip.pool_member.availability:
+    description: Availability of the pool member.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [availability.status]
+    enabled: true
+  bigip.pool_member.enabled:
+    description: Enabled state of of the pool member.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [enabled.status]
+    enabled: true
+  bigip.node.data.transmitted:
+    description: Amount of data transmitted to and from the node.
+    unit: "By"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [direction]
+    enabled: true
+  bigip.node.connection.count:
+    description: Current number of connections to the node.
+    unit: "{connections}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  bigip.node.request.count:
+    description: Number of requests to the node.
+    unit: "{requests}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  bigip.node.packet.count:
+    description: Number of packets transmitted to and from the node.
+    unit: "{packets}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [direction]
+    enabled: true
+  bigip.node.session.count:
+    description: Current number of sessions for the node.
+    unit: "{sessions}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  bigip.node.availability:
+    description: Availability of the node.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [availability.status]
+    enabled: true
+  bigip.node.enabled:
+    description: Enabled state of of the node.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [enabled.status]
+    enabled: true

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/chronyreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/chronyreceiver_metadata.yaml
@@ -1,0 +1,76 @@
+---
+type: chrony
+
+status:
+  class: receiver
+  stability:
+    alpha: [metrics]
+  distributions: [contrib]
+  codeowners:
+    active: [MovieStoreGuy, jamesmoessis]
+
+attributes:
+  leap.status:
+    description: how the chrony is handling leap seconds
+    type: string
+    enum:
+    - normal
+    - insert_second
+    - delete_second
+    - unsynchronised
+
+metrics:
+  ntp.frequency.offset:
+    enabled: false
+    description: The frequency is the rate by which the system s clock would be wrong if chronyd was not correcting it.
+    extended_documentation: "It is expressed in ppm (parts per million). For example, a value of 1 ppm would mean that when the system’s clock thinks it has advanced 1 second, it has actually advanced by 1.000001 seconds relative to true time."
+    unit: "ppm"
+    gauge:
+      value_type: double
+    attributes:
+    - leap.status
+  ntp.skew:
+    enabled: true
+    description: This is the estimated error bound on the frequency.
+    unit: "ppm"
+    gauge:
+      value_type: double
+  ntp.stratum:
+    enabled: false
+    description: The number of hops away from the reference system keeping the reference time
+    extended_documentation: To read further, refer to https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite#sect-Checking_chrony_tracking
+    unit: "{count}"
+    gauge:
+      value_type: int
+  ntp.time.correction:
+    enabled: true
+    description: The number of seconds difference between the system's clock and the reference clock
+    unit: seconds
+    gauge:
+      value_type: double
+    attributes:
+    - leap.status
+  ntp.time.last_offset:
+    enabled: true
+    description: The estimated local offset on the last clock update
+    unit: seconds
+    gauge:
+      value_type: double
+    attributes:
+    - leap.status
+  ntp.time.rms_offset:
+    enabled: false
+    description: the long term average of the offset value
+    unit: seconds
+    gauge:
+      value_type: double
+    attributes:
+    - leap.status
+  ntp.time.root_delay:
+    enabled: false
+    description: This is the total of the network path delays to the stratum-1 system from which the system is ultimately synchronised.
+    unit: seconds
+    gauge:
+      value_type: double
+    attributes:
+    - leap.status

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/couchdbreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/couchdbreceiver_metadata.yaml
@@ -1,0 +1,100 @@
+type: couchdb
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib,observiq, sumo]
+  codeowners:
+    active: [djaglowski]
+
+resource_attributes:
+  couchdb.node.name:
+    description: The name of the node.
+    type: string
+    enabled: true
+
+attributes:
+  http.method:
+    description: An HTTP request method.
+    type: string
+    enum: [ COPY, DELETE, GET, HEAD, OPTIONS, POST, PUT ]
+  http.status_code:
+    description: An HTTP status code.
+    type: string
+  view:
+    description: The view type.
+    type: string
+    enum: [ temporary_view_reads, view_reads ]
+  operation:
+    description: The operation type.
+    type: string
+    enum: [ writes, reads ]
+
+metrics:
+  couchdb.average_request_time:
+    enabled: true
+    description: The average duration of a served request.
+    unit: ms
+    gauge:
+      value_type: double
+  couchdb.httpd.bulk_requests:
+    enabled: true
+    description: The number of bulk requests.
+    unit: "{requests}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  couchdb.httpd.requests:
+    enabled: true
+    description: The number of HTTP requests by method.
+    unit: "{requests}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [ http.method ]
+  couchdb.httpd.responses:
+    enabled: true
+    description: The number of each HTTP status code.
+    unit: "{responses}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [ http.status_code ]
+  couchdb.httpd.views:
+    enabled: true
+    description: The number of views read.
+    unit: "{views}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [ view ]
+  couchdb.database.open:
+    enabled: true
+    description: The number of open databases.
+    unit: "{databases}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+  couchdb.file_descriptor.open:
+    enabled: true
+    description: The number of open file descriptors.
+    unit: "{files}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+  couchdb.database.operations:
+    enabled: true
+    description: The number of database operations.
+    unit: "{operations}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [ operation ]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/dockerstatsreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/dockerstatsreceiver_metadata.yaml
@@ -1,0 +1,696 @@
+type: docker_stats
+
+status:
+  class: receiver
+  stability:
+    alpha: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [rmfitzpatrick, jamesmoessis]
+
+sem_conv_version: 1.6.1
+
+# Note: there are other, additional resource attributes that the user can configure through the yaml
+resource_attributes:
+  container.runtime:
+    description: "The runtime of the container. For this receiver, it will always be 'docker'."
+    type: string
+    enabled: true
+  container.id:
+    description: "The ID of the container."
+    type: string
+    enabled: true
+  container.image.name:
+    description: "The name of the docker image in use by the container."
+    type: string
+    enabled: true
+  container.name:
+    description: "The name of the container."
+    type: string
+    enabled: true
+  container.hostname:
+    description: "The hostname of the container."
+    type: string
+    enabled: true
+  container.image.id:
+    description: "The ID of the container image."
+    type: string
+    enabled: false
+  container.command_line:
+    description: "The full command executed by the container."
+    type: string
+    enabled: false
+
+attributes:
+  core:
+    description: "The CPU core number when utilising per-CPU metrics."
+    type: string
+  device_major:
+    description: "Device major number for block IO operations."
+    type: string
+  device_minor:
+    description: "Device minor number for block IO operations."
+    type: string
+  interface:
+    description: "Network interface."
+    type: string
+  operation:
+    description: "Type of BlockIO operation."
+    type: string
+
+metrics:
+  # CPU
+  container.cpu.usage.system:
+    enabled: false
+    description: "System CPU usage, as reported by docker."
+    extended_documentation: "Note this is the usage for the system, not the container."
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  container.cpu.usage.total:
+    enabled: true
+    description: "Total CPU time consumed."
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  container.cpu.usage.kernelmode:
+    enabled: true
+    description: >-
+      Time spent by tasks of the cgroup in kernel mode (Linux). 
+      Time spent by all container processes in kernel mode (Windows).
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  container.cpu.usage.usermode:
+    enabled: true
+    description: >-
+      Time spent by tasks of the cgroup in user mode (Linux). 
+      Time spent by all container processes in user mode (Windows).
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  container.cpu.usage.percpu:
+    enabled: false
+    description: "Per-core CPU usage by the container (Only available with cgroups v1)."
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - core
+  container.cpu.throttling_data.periods:
+    enabled: false
+    description: "Number of periods with throttling active."
+    unit: "{periods}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  container.cpu.throttling_data.throttled_periods:
+    enabled: false
+    description: "Number of periods when the container hits its throttling limit."
+    unit: "{periods}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  container.cpu.throttling_data.throttled_time:
+    enabled: false
+    description: "Aggregate time the container was throttled."
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  container.cpu.utilization:
+    enabled: true
+    description: "Percent of CPU used by the container."
+    unit: "1"
+    gauge:
+      value_type: double
+  container.cpu.limit:
+    enabled: false
+    description: "CPU limit set for the container."
+    extended_documentation: "This metric is only reported if the container has limits set with -cpus, -cpuset-cpus or -cpu-quota."
+    unit: "{cpus}"
+    gauge:
+      value_type: double
+  container.cpu.shares:
+    enabled: false
+    description: "CPU shares set for the container."
+    unit: "1"
+    gauge:
+      value_type: int
+
+
+  # Memory
+  container.memory.usage.limit:
+    enabled: true
+    description: "Memory limit of the container."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.usage.total:
+    enabled: true
+    description: "Memory usage of the container. This excludes the cache."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.usage.max:
+    enabled: false
+    description: "Maximum memory usage."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.percent:
+    enabled: true
+    description: "Percentage of memory used."
+    unit: 1
+    gauge:
+      value_type: double
+  container.memory.cache:
+    enabled: false
+    description: "The amount of memory used by the processes of this control group that can be associated precisely with a block on a block device (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.rss:
+    enabled: false
+    description: "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.rss_huge:
+    enabled: false
+    description: "Number of bytes of anonymous transparent hugepages in this cgroup (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.dirty:
+    enabled: false
+    description: "Bytes that are waiting to get written back to the disk, from this cgroup (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.writeback:
+    enabled: false
+    description: "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.mapped_file:
+    enabled: false
+    description: "Indicates the amount of memory mapped by the processes in the control group (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.pgpgin:
+    enabled: false
+    description: "Number of pages read from disk by the cgroup (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt)."
+    unit: "{operations}"
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+  container.memory.pgpgout:
+    enabled: false
+    description: "Number of pages written to disk by the cgroup (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt)."
+    unit: "{operations}"
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+  container.memory.pgfault:
+    enabled: false
+    description: "Indicate the number of times that a process of the cgroup triggered a page fault."
+    unit: "{faults}"
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+  container.memory.pgmajfault:
+    enabled: false
+    description: "Indicate the number of times that a process of the cgroup triggered a major fault."
+    unit: "{faults}"
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+  container.memory.inactive_anon:
+    enabled: false
+    description: "The amount of anonymous memory that has been identified as inactive by the kernel."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.active_anon:
+    enabled: false
+    description: "The amount of anonymous memory that has been identified as active by the kernel."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.inactive_file:
+    enabled: false
+    description: "Cache memory that has been identified as inactive by the kernel."
+    extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)"
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.active_file:
+    enabled: false
+    description: "Cache memory that has been identified as active by the kernel."
+    extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)"
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.unevictable:
+    enabled: false
+    description: "The amount of memory that cannot be reclaimed."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.hierarchical_memory_limit:
+    enabled: false
+    description: "The maximum amount of physical memory that can be used by the processes of this control group (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.hierarchical_memsw_limit:
+    enabled: false
+    description: "The maximum amount of RAM + swap that can be used by the processes of this control group (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_cache:
+    enabled: true
+    description: "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_rss:
+    enabled: false
+    description: "The amount of memory that doesn’t correspond to anything on disk: stacks, heaps, and anonymous memory maps. Includes descendant cgroups (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_rss_huge:
+    enabled: false
+    description: "Number of bytes of anonymous transparent hugepages in this cgroup and descendant cgroups (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_dirty:
+    enabled: false
+    description: "Bytes that are waiting to get written back to the disk, from this cgroup and descendants (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_writeback:
+    enabled: false
+    description: "Number of bytes of file/anon cache that are queued for syncing to disk in this cgroup and descendants (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_mapped_file:
+    enabled: false
+    description: "Indicates the amount of memory mapped by the processes in the control group and descendant groups (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_pgpgin:
+    enabled: false
+    description: "Number of pages read from disk by the cgroup and descendant groups (Only available with cgroups v1)."
+    unit: "{operations}"
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+  container.memory.total_pgpgout:
+    enabled: false
+    description: "Number of pages written to disk by the cgroup and descendant groups (Only available with cgroups v1)."
+    unit: "{operations}"
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+  container.memory.total_pgfault:
+    enabled: false
+    description: "Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a page fault (Only available with cgroups v1)."
+    unit: "{faults}"
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+  container.memory.total_pgmajfault:
+    enabled: false
+    description: "Indicate the number of times that a process of the cgroup (or descendant cgroups) triggered a major fault (Only available with cgroups v1)."
+    unit: "{faults}"
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+  container.memory.total_inactive_anon:
+    enabled: false
+    description: "The amount of anonymous memory that has been identified as inactive by the kernel. Includes descendant cgroups (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_active_anon:
+    enabled: false
+    description: "The amount of anonymous memory that has been identified as active by the kernel. Includes descendant cgroups (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_inactive_file:
+    enabled: false
+    description: "Cache memory that has been identified as inactive by the kernel. Includes descendant cgroups (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_active_file:
+    enabled: false
+    description: "Cache memory that has been identified as active by the kernel. Includes descendant cgroups (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://docs.docker.com/config/containers/runmetrics/)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.total_unevictable:
+    enabled: false
+    description: "The amount of memory that cannot be reclaimed. Includes descendant cgroups (Only available with cgroups v1)."
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.anon:
+    enabled: false
+    description: "Amount of memory used in anonymous mappings such as brk(), sbrk(), and mmap(MAP_ANONYMOUS) (Only available with cgroups v2)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v2.txt)"
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+  container.memory.file:
+    enabled: true
+    description: "Amount of memory used to cache filesystem data, including tmpfs and shared memory (Only available with cgroups v2)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v2.txt)"
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+
+
+  # BlockIO (cgroup v1) and IO (cgroup v2) controllers
+  container.blockio.io_merged_recursive:
+    enabled: false
+    description: "Number of bios/requests merged into requests belonging to this cgroup and its descendant cgroups (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
+    unit: "{operations}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - device_major
+      - device_minor
+      - operation
+  container.blockio.io_queued_recursive:
+    enabled: false
+    description: "Number of requests queued up for this cgroup and its descendant cgroups (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
+    unit: "{operations}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - device_major
+      - device_minor
+      - operation
+  container.blockio.io_service_bytes_recursive:
+    enabled: true
+    description: "Number of bytes transferred to/from the disk by the group and descendant groups."
+    extended_documentation: >-
+      More docs
+      for [cgroups v1](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)
+      and [cgroups v2](https://www.kernel.org/doc/Documentation/cgroup-v2.txt)
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - device_major
+      - device_minor
+      - operation
+  container.blockio.io_service_time_recursive:
+    enabled: false
+    description: "Total amount of time in nanoseconds between request dispatch and request completion for the IOs done by this cgroup and descendant cgroups (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - device_major
+      - device_minor
+      - operation
+  container.blockio.io_serviced_recursive:
+    enabled: false
+    description: "Number of IOs (bio) issued to the disk by the group and descendant groups (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
+    unit: "{operations}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - device_major
+      - device_minor
+      - operation
+  container.blockio.io_time_recursive:
+    enabled: false
+    description: "Disk time allocated to cgroup (and descendant cgroups) per device in milliseconds (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
+    unit: ms
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - device_major
+      - device_minor
+      - operation
+  container.blockio.io_wait_time_recursive:
+    enabled: false
+    description: "Total amount of time the IOs for this cgroup (and descendant cgroups) spent waiting in the scheduler queues for service (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - device_major
+      - device_minor
+      - operation
+  container.blockio.sectors_recursive:
+    enabled: false
+    description: "Number of sectors transferred to/from disk by the group and descendant groups (Only available with cgroups v1)."
+    extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
+    unit: "{sectors}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - device_major
+      - device_minor
+      - operation
+
+  # Network
+  container.network.io.usage.rx_bytes:
+    enabled: true
+    description: "Bytes received by the container."
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - interface
+  container.network.io.usage.tx_bytes:
+    enabled: true
+    description: "Bytes sent."
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - interface
+  container.network.io.usage.rx_dropped:
+    enabled: true
+    description: "Incoming packets dropped."
+    unit: "{packets}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - interface
+  container.network.io.usage.tx_dropped:
+    enabled: true
+    description: "Outgoing packets dropped."
+    unit: "{packets}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - interface
+  container.network.io.usage.rx_errors:
+    enabled: false
+    description: "Received errors."
+    unit: "{errors}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - interface
+  container.network.io.usage.tx_errors:
+    enabled: false
+    description: "Sent errors."
+    unit: "{errors}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - interface
+  container.network.io.usage.rx_packets:
+    enabled: false
+    description: "Packets received."
+    unit: "{packets}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - interface
+  container.network.io.usage.tx_packets:
+    enabled: false
+    description: "Packets sent."
+    unit: "{packets}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      - interface
+
+  # Pids
+  container.pids.count:
+    enabled: false
+    description: "Number of pids in the container's cgroup."
+    extended_documentation: "It requires docker API 1.23 or higher and kernel version >= 4.3 with pids cgroup supported. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt)"
+    unit: "{pids}"
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+
+  container.pids.limit:
+    enabled: false
+    description: "Maximum number of pids in the container's cgroup."
+    extended_documentation: "It requires docker API 1.23 or higher and kernel version >= 4.3 with pids cgroup supported. [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt)"
+    unit: "{pids}"
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+
+  # Base
+  container.uptime:
+    enabled: false
+    description: "Time elapsed since container start time."
+    unit: s
+    gauge:
+      value_type: double
+
+  # Container
+  container.restarts:
+    enabled: false
+    description: "Number of restarts for the container."
+    unit: "{restarts}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/elasticsearchreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/elasticsearchreceiver_metadata.yaml
@@ -1,0 +1,994 @@
+type: elasticsearch
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski, BinaryFissionGames]
+
+resource_attributes:
+  elasticsearch.cluster.name:
+    description: The name of the elasticsearch cluster.
+    type: string
+    enabled: true
+  elasticsearch.node.name:
+    description: The name of the elasticsearch node.
+    type: string
+    enabled: true
+  elasticsearch.node.version:
+    description: The version of the elasticsearch node.
+    type: string
+    enabled: true
+  elasticsearch.index.name:
+    description: The name of the elasticsearch index.
+    type: string
+    enabled: true
+
+attributes:
+  cache_name:
+    description: The name of cache.
+    type: string
+    enum:
+    - fielddata
+    - query
+  collector_name:
+    name_override: name
+    description: The name of the garbage collector.
+    type: string
+  memory_pool_name:
+    name_override: name
+    description: The name of the JVM memory pool.
+    type: string
+  direction:
+    description: The direction of network data.
+    type: string
+    enum:
+    - received
+    - sent
+  document_state:
+    name_override: state
+    description: The state of the document.
+    type: string
+    enum:
+    - active
+    - deleted
+  shard_state:
+    name_override: state
+    description: The state of the shard.
+    type: string
+    enum:
+    - active
+    - active_primary
+    - relocating
+    - initializing
+    - unassigned
+    - unassigned_delayed
+  operation:
+    name_override: operation
+    description: The type of operation.
+    type: string
+    enum:
+    - index
+    - delete
+    - get
+    - query
+    - fetch
+    - scroll
+    - suggest
+    - merge
+    - refresh
+    - flush
+    - warmer
+  thread_pool_name:
+    description: The name of the thread pool.
+    type: string
+  thread_state:
+    name_override: state
+    description: The state of the thread.
+    type: string
+    enum:
+    - active
+    - idle
+  task_state:
+    name_override: state
+    description: The state of the task.
+    type: string
+    enum:
+    - rejected
+    - completed
+  health_status:
+    name_override: status
+    description: The health status of the cluster.
+    type: string
+    enum:
+    - green
+    - yellow
+    - red
+  circuit_breaker_name:
+    name_override: name
+    description: The name of circuit breaker.
+    type: string
+  memory_state:
+    name_override: state
+    description: State of the memory
+    type: string
+    enum:
+      - free
+      - used
+  cluster_published_difference_state:
+    name_override: state
+    description: State of the published differences
+    type: string
+    enum:
+      - incompatible
+      - compatible
+  cluster_state_queue_state:
+    name_override: state
+    description: State of the published differences
+    type: string
+    enum:
+      - pending
+      - committed
+  indexing_pressure_stage:
+    name_override: stage
+    description: Stage of the indexing pressure
+    type: string
+    enum:
+      - coordinating
+      - primary
+      - replica
+  cluster_state_update_state:
+    name_override: state
+    description: State of cluster state update
+    type: string
+  cluster_state_update_type:
+    name_override: type
+    description: Type of cluster state update
+    type: string
+    enum:
+      - computation
+      - context_construction
+      - commit
+      - completion
+      - master_apply
+      - notification
+  ingest_pipeline_name:
+    name_override: name
+    description: Name of the ingest pipeline.
+    type: string
+  query_cache_count_type:
+    name_override: type
+    description: Type of query cache count
+    type: string
+    enum:
+      - hit
+      - miss
+  index_aggregation_type:
+    name_override: aggregation
+    description: Type of shard aggregation for index statistics
+    type: string
+    enum:
+      - primary_shards
+      - total
+  segments_memory_object_type:
+    name_override: object
+    description: Type of object in segment
+    type: string
+    enum:
+      - term
+      - doc_value
+      - index_writer
+      - fixed_bit_set
+  get_result:
+    name_override: result
+    description: Result of get operation
+    type: string
+    enum:
+      - hit
+      - miss
+
+metrics:
+  # these metrics are from /_nodes/stats, and are node level metrics
+  elasticsearch.breaker.memory.estimated:
+    description: Estimated memory used for the operation.
+    unit: By
+    gauge:
+      value_type: int
+    attributes: [circuit_breaker_name]
+    enabled: true
+  elasticsearch.breaker.memory.limit:
+    description: Memory limit for the circuit breaker.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [circuit_breaker_name]
+    enabled: true
+  elasticsearch.breaker.tripped:
+    description: Total number of times the circuit breaker has been triggered and prevented an out of memory error.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [circuit_breaker_name]
+    enabled: true
+  elasticsearch.node.cache.memory.usage:
+    description: The size in bytes of the cache on a node.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [cache_name]
+    enabled: true
+  elasticsearch.node.cache.evictions:
+    description: The number of evictions from the cache on a node.
+    unit: "{evictions}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [cache_name]
+    enabled: true
+  elasticsearch.node.cache.count:
+    description: Total count of query cache misses across all shards assigned to selected nodes.
+    unit: "{count}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ query_cache_count_type ]
+    enabled: true
+  elasticsearch.node.cache.size:
+    description: Total amount of memory used for the query cache across all shards assigned to the node.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: false
+  elasticsearch.node.fs.disk.available:
+    description: The amount of disk space available to the JVM across all file stores for this node. Depending on OS or process level restrictions, this might appear less than free. This is the actual amount of free disk space the Elasticsearch node can utilise.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: []
+    enabled: true
+  elasticsearch.node.fs.disk.free:
+    description: The amount of unallocated disk space across all file stores for this node.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: []
+    enabled: true
+  elasticsearch.node.fs.disk.total:
+    description: The amount of disk space across all file stores for this node.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: []
+    enabled: true
+  # The calculation for node.disk.io.read is actually in KiBy(1024 bytes), not kBy (1000 bytes)
+  # The metric value calculation comes from sectors: https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java#L287
+  # The metric value is gathered by reading disk stats files from https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java#L117
+  # which come from a kernel https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
+  # Linux always considers sectors to be 512 bytes https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/linux/types.h#L125
+  elasticsearch.node.disk.io.read:
+    description: The total number of kilobytes read across all file stores for this node.
+    unit: KiBy
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  # The calculation for node.disk.io.write is actually in KiBy(1024 bytes), not kBy (1000 bytes)
+  # The metric value calculation comes from sectors: https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java#L293
+  # The metric value is gathered by reading disk stats files from https://github.com/elastic/elasticsearch/blob/3c6797f2d2271a30b24f505da55afbb5ea10733e/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java#L117
+  # which come from a kernel https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
+  # Linux always considers sectors to be 512 bytes https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/linux/types.h#L125
+  elasticsearch.node.disk.io.write:
+    description: The total number of kilobytes written across all file stores for this node.
+    unit: KiBy
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.cluster.io:
+    description: The number of bytes sent and received on the network for internal cluster communication.
+    unit: By
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [direction]
+    enabled: true
+  elasticsearch.node.cluster.connections:
+    description: The number of open tcp connections for internal cluster communication.
+    unit: "{connections}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: []
+    enabled: true
+  elasticsearch.node.http.connections:
+    description: The number of HTTP connections to the node.
+    unit: "{connections}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: []
+    enabled: true
+  elasticsearch.node.operations.current:
+    description: Number of query operations currently running.
+    unit: "{operations}"
+    gauge:
+      value_type: int
+    attributes: [ operation ]
+    enabled: false
+  elasticsearch.node.operations.completed:
+    description: The number of operations completed by a node.
+    unit: "{operations}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [operation]
+    enabled: true
+  elasticsearch.node.operations.time:
+    description: Time spent on operations by a node.
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [operation]
+    enabled: true
+  elasticsearch.node.operations.get.completed:
+    description: The number of hits and misses resulting from GET operations.
+    unit: "{operations}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [get_result]
+    enabled: false
+  elasticsearch.node.operations.get.time:
+    description: The time spent on hits and misses resulting from GET operations.
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [get_result]
+    enabled: false
+  elasticsearch.node.shards.size:
+    description: The size of the shards assigned to this node.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: []
+    enabled: true
+  elasticsearch.node.shards.data_set.size:
+    description: Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.shards.reserved.size:
+    description: A prediction of how much larger the shard stores on this node will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities. A value of -1 indicates that this is not available.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.translog.operations:
+    description: Number of transaction log operations.
+    unit: "{operations}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.translog.size:
+    description: Size of the transaction log.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.translog.uncommitted.size:
+    description: Size of uncommitted transaction log operations.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.thread_pool.threads:
+    description: The number of threads in the thread pool.
+    unit: "{threads}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [thread_pool_name, thread_state]
+    enabled: true
+  elasticsearch.node.thread_pool.tasks.queued:
+    description: The number of queued tasks in the thread pool.
+    unit: "{tasks}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [thread_pool_name]
+    enabled: true
+  elasticsearch.node.thread_pool.tasks.finished:
+    description: The number of tasks finished by the thread pool.
+    unit: "{tasks}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [thread_pool_name, task_state]
+    enabled: true
+  elasticsearch.node.documents:
+    description: The number of documents on the node.
+    unit: "{documents}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [document_state]
+    enabled: true
+  elasticsearch.node.open_files:
+    description: The number of open file descriptors held by the node.
+    unit: "{files}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: []
+    enabled: true
+  # These metrics are JVM metrics, collected from /_nodes/stats
+  # See https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics/docs/target-systems/jvm.md
+  jvm.classes.loaded:
+    description: The number of loaded classes
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []
+    enabled: true
+  jvm.gc.collections.count:
+    description: The total number of garbage collections that have occurred
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [collector_name]
+    enabled: true
+  jvm.gc.collections.elapsed:
+    description: "The approximate accumulated collection elapsed time"
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [collector_name]
+    enabled: true
+  jvm.memory.heap.max:
+    description: The maximum amount of memory can be used for the heap
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+    enabled: true
+  jvm.memory.heap.used:
+    description: The current heap memory usage
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+    enabled: true
+  jvm.memory.heap.utilization:
+    description: Fraction of heap memory usage
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: []
+    enabled: false
+  jvm.memory.heap.committed:
+    description: The amount of memory that is guaranteed to be available for the heap
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+    enabled: true
+  jvm.memory.nonheap.used:
+    description: The current non-heap memory usage
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+    enabled: true
+  jvm.memory.nonheap.committed:
+    description: The amount of memory that is guaranteed to be available for non-heap purposes
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+    enabled: true
+  jvm.memory.pool.max:
+    description: The maximum amount of memory can be used for the memory pool
+    unit: By
+    gauge:
+      value_type: int
+    attributes: [memory_pool_name]
+    enabled: true
+  jvm.memory.pool.used:
+    description: The current memory pool memory usage
+    unit: By
+    gauge:
+      value_type: int
+    attributes: [memory_pool_name]
+    enabled: true
+  jvm.threads.count:
+    description: The current number of threads
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []
+    enabled: true
+  # these metrics are from /_cluster/pending_tasks, and are cluster level metrics
+  elasticsearch.cluster.pending_tasks:
+    description: The number of cluster-level changes that have not yet been executed.
+    unit: "{tasks}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.cluster.in_flight_fetch:
+    description: The number of unfinished fetches.
+    unit: "{fetches}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  # these metrics are from /_cluster/health, and are cluster level metrics
+  elasticsearch.cluster.shards:
+    description: The number of shards in the cluster.
+    unit: "{shards}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [shard_state]
+    enabled: true
+  elasticsearch.cluster.data_nodes:
+    description: The number of data nodes in the cluster.
+    unit: "{nodes}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: []
+    enabled: true
+  elasticsearch.cluster.nodes:
+    description: The total number of nodes in the cluster.
+    unit: "{nodes}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: []
+    enabled: true
+  elasticsearch.cluster.health:
+    description: The health status of the cluster.
+    extended_documentation:
+      Health status is based on the state of its primary and replica shards.
+      Green indicates all shards are assigned.
+      Yellow indicates that one or more replica shards are unassigned.
+      Red indicates that one or more primary shards are unassigned, making some data unavailable.
+    unit: "{status}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [health_status]
+    enabled: true
+  elasticsearch.os.cpu.usage:
+    description: Recent CPU usage for the whole system, or -1 if not supported.
+    unit: '%'
+    gauge:
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.os.cpu.load_avg.1m:
+    description: One-minute load average on the system (field is not present if one-minute load average is not available).
+    unit: 1.0
+    gauge:
+      value_type: double
+    attributes: [ ]
+    enabled: true
+  elasticsearch.os.cpu.load_avg.5m:
+    description: Five-minute load average on the system (field is not present if five-minute load average is not available).
+    unit: 1.0
+    gauge:
+      value_type: double
+    attributes: [ ]
+    enabled: true
+  elasticsearch.os.cpu.load_avg.15m:
+    description: Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).
+    unit: 1.0
+    gauge:
+      value_type: double
+    attributes: [ ]
+    enabled: true
+  elasticsearch.os.memory:
+    description: Amount of physical memory.
+    unit: By
+    gauge:
+      value_type: int
+    attributes: [memory_state]
+    enabled: true
+  elasticsearch.memory.indexing_pressure:
+    description: Memory consumed, in bytes, by indexing requests in the specified stage.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [  indexing_pressure_stage ]
+    enabled: true
+  elasticsearch.indexing_pressure.memory.total.primary_rejections:
+    description: Cumulative number of indexing requests rejected in the primary stage.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.indexing_pressure.memory.total.replica_rejections:
+    description: Number of indexing requests rejected in the replica stage.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.indexing_pressure.memory.limit:
+    description: Configured memory limit, in bytes, for the indexing requests.
+    unit: By
+    gauge:
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.cluster.state_queue:
+    description: Number of cluster states in queue.
+    unit: 1
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ cluster_state_queue_state ]
+    enabled: true
+  elasticsearch.cluster.published_states.full:
+    description: Number of published cluster states.
+    unit: 1
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.cluster.published_states.differences:
+    description: Number of differences between published cluster states.
+    unit: 1
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ cluster_published_difference_state ]
+    enabled: true
+  elasticsearch.cluster.state_update.count:
+    description: The number of cluster state update attempts that changed the cluster state since the node started.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ cluster_state_update_state ]
+    enabled: true
+  elasticsearch.cluster.state_update.time:
+    description: The cumulative amount of time updating the cluster state since the node started.
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ cluster_state_update_state, cluster_state_update_type ]
+    enabled: true
+  elasticsearch.cluster.indices.cache.evictions:
+    description: The number of evictions from the cache for indices in cluster.
+    unit: "{evictions}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [cache_name]
+    enabled: false
+  elasticsearch.node.ingest.documents:
+    description: Total number of documents ingested during the lifetime of this node.
+    unit: "{documents}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.ingest.documents.current:
+    description: Total number of documents currently being ingested.
+    unit: "{documents}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.ingest.operations.failed:
+    description: Total number of failed ingest operations during the lifetime of this node.
+    unit: "{operation}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.pipeline.ingest.documents.preprocessed:
+    description: Number of documents preprocessed by the ingest pipeline.
+    unit: "{documents}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ingest_pipeline_name ]
+    enabled: true
+  elasticsearch.node.pipeline.ingest.operations.failed:
+    description: Total number of failed operations for the ingest pipeline.
+    unit: "{operation}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ingest_pipeline_name ]
+    enabled: true
+  elasticsearch.node.pipeline.ingest.documents.current:
+    description: Total number of documents currently being ingested by a pipeline.
+    unit: "{documents}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ingest_pipeline_name ]
+    enabled: true
+  elasticsearch.node.script.compilations:
+    description: Total number of inline script compilations performed by the node.
+    unit: "{compilations}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.script.cache_evictions:
+    description: Total number of times the script cache has evicted old data.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.script.compilation_limit_triggered:
+    description: Total number of times the script compilation circuit breaker has limited inline script compilations.
+    unit: 1
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: true
+  elasticsearch.node.segments.memory:
+    description: Size of memory for segment object of a node.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [segments_memory_object_type]
+    enabled: false
+  # these metrics are from /*/_stats and are index level metrics
+  elasticsearch.index.operations.completed:
+    description: The number of operations completed for an index.
+    unit: "{operations}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [operation, index_aggregation_type]
+    enabled: true
+  elasticsearch.index.operations.time:
+    description: Time spent on operations for an index.
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [operation, index_aggregation_type]
+    enabled: true
+  elasticsearch.index.shards.size:
+    description: The size of the shards assigned to this index.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [index_aggregation_type]
+    enabled: true
+  elasticsearch.index.operations.merge.size:
+    description: The total size of merged segments for an index.
+    unit: By
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [index_aggregation_type]
+    enabled: false
+  elasticsearch.index.operations.merge.docs_count:
+    description: The total number of documents in merge operations for an index.
+    unit: "{documents}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [index_aggregation_type]
+    enabled: false
+  elasticsearch.index.segments.count:
+    description: Number of segments of an index.
+    unit: "{segments}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [index_aggregation_type]
+    enabled: false
+  elasticsearch.index.segments.size:
+    description: Size of segments of an index.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [index_aggregation_type]
+    enabled: false
+  elasticsearch.index.segments.memory:
+    description: Size of memory for segment object of an index.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [index_aggregation_type, segments_memory_object_type]
+    enabled: false
+  elasticsearch.index.translog.operations:
+    description: Number of transaction log operations for an index.
+    unit: "{operations}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [index_aggregation_type]
+    enabled: false
+  elasticsearch.index.translog.size:
+    description: Size of the transaction log for an index.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [index_aggregation_type]
+    enabled: false
+  elasticsearch.index.cache.memory.usage:
+    description: The size in bytes of the cache for an index.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [cache_name, index_aggregation_type]
+    enabled: false
+  elasticsearch.index.cache.size:
+    description: The number of elements of the query cache for an index.
+    unit: 1
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [index_aggregation_type]
+    enabled: false
+  elasticsearch.index.cache.evictions:
+    description: The number of evictions from the cache for an index.
+    unit: "{evictions}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [cache_name, index_aggregation_type]
+    enabled: false
+  elasticsearch.index.documents:
+    description: The number of documents for an index.
+    unit: "{documents}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [document_state, index_aggregation_type]
+    enabled: false
+  elasticsearch.process.cpu.usage:
+    description: CPU usage in percent.
+    unit: 1.0
+    gauge:
+      value_type: double
+    attributes: [ ]
+    enabled: false
+  elasticsearch.process.cpu.time:
+    description: CPU time used by the process on which the Java virtual machine is running.
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: false
+  elasticsearch.process.memory.virtual:
+    description: Size of virtual memory that is guaranteed to be available to the running process.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [ ]
+    enabled: false

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/expvarreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/expvarreceiver_metadata.yaml
@@ -1,0 +1,266 @@
+type: expvar
+
+status:
+  class: receiver
+  stability:
+    alpha: [metrics]
+  distributions: [contrib, sumo]
+  codeowners:
+    active: [jamesmoessis, MovieStoreGuy]
+
+metrics:
+  process.runtime.memstats.total_alloc:
+    enabled: false
+    description: Cumulative bytes allocated for heap objects.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.sys:
+    enabled: true
+    description: Total bytes of memory obtained from the OS.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.lookups:
+    enabled: false
+    description: Number of pointer lookups performed by the runtime.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: "{lookups}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.mallocs:
+    enabled: true
+    description: Cumulative count of heap objects allocated.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: "{objects}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.frees:
+    enabled: true
+    description: Cumulative count of heap objects freed.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: "{objects}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.heap_alloc:
+    enabled: true
+    description: Bytes of allocated heap objects.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.heap_sys:
+    enabled: true
+    description: Bytes of heap memory obtained by the OS.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.heap_idle:
+    enabled: true
+    description: Bytes in idle (unused) spans.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.heap_inuse:
+    enabled: true
+    description: Bytes in in-use spans.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.heap_released:
+    enabled: true
+    description: Bytes of physical memory returned to the OS.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.heap_objects:
+    enabled: true
+    description: Number of allocated heap objects.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: "{objects}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.stack_inuse:
+    enabled: true
+    description: Bytes in stack spans.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.stack_sys:
+    enabled: true
+    description: Bytes of stack memory obtained from the OS.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.mspan_inuse:
+    enabled: true
+    description: Bytes of allocated mspan structures.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.mspan_sys:
+    enabled: true
+    description: Bytes of memory obtained from the OS for mspan structures.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.mcache_inuse:
+    enabled: true
+    description: Bytes of allocated mcache structures.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.mcache_sys:
+    enabled: true
+    description: Bytes of memory obtained from the OS for mcache structures.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.buck_hash_sys:
+    enabled: true
+    description: Bytes of memory in profiling bucket hash tables.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.gc_sys:
+    enabled: true
+    description: Bytes of memory in garbage collection metadata.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.other_sys:
+    enabled: true
+    description: Bytes of memory in miscellaneous off-heap runtime allocations.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.next_gc:
+    enabled: true
+    description: The target heap size of the next GC cycle.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.pause_total:
+    enabled: true
+    description: The cumulative nanoseconds in GC stop-the-world pauses since the program started.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.last_pause:
+    enabled: true
+    description: The most recent stop-the-world pause time.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: ns
+    gauge:
+      value_type: int
+
+  process.runtime.memstats.num_gc:
+    enabled: true
+    description: Number of completed GC cycles.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.num_forced_gc:
+    enabled: true
+    description: Number of GC cycles that were forced by the application calling the GC function.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  process.runtime.memstats.gc_cpu_fraction:
+    enabled: true
+    description: The fraction of this program's available CPU time used by the GC since the program started.
+    extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
+    unit: 1
+    gauge:
+      value_type: double

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/filestatsreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/filestatsreceiver_metadata.yaml
@@ -1,0 +1,59 @@
+type: filestats
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, sumo]
+  codeowners:
+    active: [atoulme]
+
+
+resource_attributes:
+  file.name:
+    description: The name of the file
+    enabled: true
+    type: string
+  file.path:
+    description: The absolute path of the file
+    enabled: false
+    type: string
+
+attributes:
+  file.permissions:
+    description: the permissions associated with the file, using an octal format.
+    type: string
+
+metrics:
+  file.mtime:
+    description: Elapsed time since the last modification of the file or folder, in seconds since Epoch.
+    enabled: true
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    unit: "s"
+  file.ctime:
+    description: Elapsed time since the last change of the file or folder, in seconds since Epoch. In addition to `file.mtime`, this metric tracks metadata changes such as permissions or renaming the file.
+    enabled: false
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    unit: "s"
+    attributes:
+      - file.permissions
+  file.atime:
+    description: Elapsed time since last access of the file or folder, in seconds since Epoch.
+    enabled: false
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    unit: "s"
+  file.size:
+    description: The size of the file or folder, in bytes.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: "b"

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/flinkmetricsreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/flinkmetricsreceiver_metadata.yaml
@@ -1,0 +1,344 @@
+type: flinkmetrics
+
+status:
+  class: receiver
+  stability:
+    alpha: [metrics]
+  distributions: [contrib,observiq, sumo]
+  codeowners:
+    active: [JonathanWamsley, djaglowski]
+
+resource_attributes:
+  # These resource attributes are Flinks system scope variables, which contains context information about metrics. These are required to uniquely identify incoming metrics as the same job can run multiple times concurrently. See https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/ops/metrics/#system-scope for more information.
+  host.name:
+    description: The host name.
+    type: string
+    enabled: true
+  flink.taskmanager.id:
+    description: The taskmanager ID.
+    type: string
+    enabled: true
+  flink.job.name:
+    description: The job name.
+    type: string
+    enabled: true
+  flink.task.name:
+    description: The task name.
+    type: string
+    enabled: true
+  flink.subtask.index:
+    description: The subtask index.
+    type: string
+    enabled: true
+  flink.resource.type:
+    description: The flink scope type in which a metric belongs to.
+    type: string
+    enabled: true
+    enum: [ jobmanager, taskmanager ]
+
+attributes:
+  operator_name:
+    name_override: name
+    description: The operator name.
+    type: string
+  garbage_collector_name:
+    name_override: name
+    description: The names for the parallel scavenge and garbage first garbage collectors.
+    type: string
+    enum: [ PS_MarkSweep, PS_Scavenge, G1_Young_Generation, G1_Old_Generation ]
+  checkpoint:
+    description: The number of checkpoints completed or that failed.
+    type: string
+    enum: [ completed, failed ]
+  record:
+    description: The number of records received in, sent out or dropped due to arriving late.
+    type: string
+    enum: [ in, out, dropped ]
+
+metrics:
+  flink.jvm.cpu.load:
+    enabled: true
+    description: The CPU usage of the JVM for a jobmanager or taskmanager.
+    unit: "%"
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: []
+  flink.jvm.cpu.time:
+    enabled: true
+    description: The CPU time used by the JVM for a jobmanager or taskmanager.
+    unit: ns
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.heap.used:
+    enabled: true
+    description: The amount of heap memory currently used.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.heap.committed:
+    enabled: true
+    description: The amount of heap memory guaranteed to be available to the JVM.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.heap.max:
+    enabled: true
+    description: The maximum amount of heap memory that can be used for memory management.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.nonheap.used:
+    enabled: true
+    description: The amount of non-heap memory currently used.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.nonheap.committed:
+    enabled: true
+    description: The amount of non-heap memory guaranteed to be available to the JVM.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.nonheap.max:
+    enabled: true
+    description: The maximum amount of non-heap memory that can be used for memory management.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.metaspace.used:
+    enabled: true
+    description: The amount of memory currently used in the Metaspace memory pool.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.metaspace.committed:
+    enabled: true
+    description: The amount of memory guaranteed to be available to the JVM in the Metaspace memory pool.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.metaspace.max:
+    enabled: true
+    description: The maximum amount of memory that can be used in the Metaspace memory pool.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.direct.used:
+    enabled: true
+    description: The amount of memory used by the JVM for the direct buffer pool.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.direct.total_capacity:
+    enabled: true
+    description: The total capacity of all buffers in the direct buffer pool.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.mapped.used:
+    enabled: true
+    description: The amount of memory used by the JVM for the mapped buffer pool.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.memory.mapped.total_capacity:
+    enabled: true
+    description: The number of buffers in the mapped buffer pool.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.memory.managed.used:
+    enabled: true
+    description: The amount of managed memory currently used.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.memory.managed.total:
+    enabled: true
+    description: The total amount of managed memory.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.threads.count:
+    enabled: true
+    description: The total number of live threads.
+    unit: "{threads}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.jvm.gc.collections.count:
+    enabled: true
+    description: The total number of collections that have occurred.
+    unit: "{collections}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [ garbage_collector_name ]
+  flink.jvm.gc.collections.time:
+    enabled: true
+    description: The total time spent performing garbage collection.
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [ garbage_collector_name ]
+  flink.jvm.class_loader.classes_loaded:
+    enabled: true
+    description: The total number of classes loaded since the start of the JVM.
+    unit: "{classes}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.job.restart.count:
+    enabled: true
+    description: The total number of restarts since this job was submitted, including full restarts and fine-grained restarts.
+    unit: "{restarts}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.job.last_checkpoint.time:
+    enabled: true
+    description: The end to end duration of the last checkpoint.
+    unit: ms
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.job.last_checkpoint.size:
+    enabled: true
+    description: The total size of the last checkpoint.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.job.checkpoint.count:
+    enabled: true
+    description: The number of checkpoints completed or failed.
+    unit: "{checkpoints}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [ checkpoint ]
+  flink.job.checkpoint.in_progress:
+    enabled: true
+    description: The number of checkpoints in progress.
+    unit: "{checkpoints}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+  flink.task.record.count:
+    enabled: true
+    description: The number of records a task has.
+    unit: "{records}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [ record ]
+  flink.operator.record.count:
+    enabled: true
+    description: The number of records an operator has.
+    unit: "{records}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [ operator_name, record ]
+  flink.operator.watermark.output:
+    enabled: true
+    description: The last watermark this operator has emitted.
+    unit: ms
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [ operator_name ]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/gitproviderreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/gitproviderreceiver_metadata.yaml
@@ -1,0 +1,52 @@
+type: gitprovider
+
+sem_conv_version: 1.9.0
+
+status:
+  class: receiver
+  stability:
+    development: [metrics]
+  distributions: [liatrio]
+  codeowners:
+    active: [adrielp, astencel-sumo]
+
+# this might need to be unique per sub receiver implementation
+resource_attributes:
+  organization.name:
+      enabled: true
+      description: Git Organization or Project Name
+      type: string
+  git.vendor.name:
+      enabled: true
+      # github, gitlab, bitbucket, gittea
+      description: The name of the Git vendor/provider (ie. GitHub / GitLab)
+      type: string
+
+## Attritbutes that will be uncommented when the rest of the metrics are added
+attributes:
+  repository.name:
+      description: The full name of the Git repository
+      type: string
+
+metrics:
+  git.repository.count:
+      enabled: true
+      description: Number of repositories in an organization
+      unit: 1
+      gauge:
+          value_type: int
+      attributes: []
+  git.repository.branch.count:
+      enabled: true
+      description: Number of branches in the repository
+      unit: 1
+      gauge:
+          value_type: int
+      attributes: [repository.name]
+  git.repository.contributor.count:
+      enabled: false
+      description: Total number of unique contributors to this repository
+      unit: 1
+      gauge:
+          value_type: int
+      attributes: [repository.name]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/haproxyreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/haproxyreceiver_metadata.yaml
@@ -1,0 +1,263 @@
+type: haproxy
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, sumo]
+  codeowners:
+    active: [atoulme, MovieStoreGuy]
+
+resource_attributes:
+  haproxy.addr:
+    description: address:port or "unix". IPv6 has brackets around the address.
+    enabled: true
+    type: string
+  haproxy.proxy_name:
+    description: Proxy name
+    enabled: true
+    type: string
+  haproxy.service_name:
+    description: Service name (FRONTEND for frontend, BACKEND for backend, any name for server/listener)
+    enabled: true
+    type: string
+
+attributes:
+  status_code:
+    description: Status code category, 1xx, 2xx, 3xx, 4xx, 5xx or other
+    type: string
+    enum:
+      - "1xx"
+      - "2xx"
+      - "3xx"
+      - "4xx"
+      - "5xx"
+      - "other"
+
+
+metrics:
+  haproxy.connections.rate:
+    description: Number of connections over the last elapsed second (frontend). Corresponds to HAProxy's `conn_rate` metric.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{connections}"
+  haproxy.sessions.count:
+    description: Current sessions. Corresponds to HAProxy's `scur` metric.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{sessions}"
+  haproxy.connections.total:
+    description: Cumulative number of connections (frontend). Corresponds to HAProxy's `conn_tot` metric.
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{connections}"
+  haproxy.server_selected.total:
+    description: Number of times a server was selected, either for new sessions or when re-dispatching. Corresponds to HAProxy's `lbtot` metric.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{selections}"
+  haproxy.bytes.input:
+    description: Bytes in. Corresponds to HAProxy's `bin` metric.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: by
+  haproxy.bytes.output:
+    description: Bytes out. Corresponds to HAProxy's `bout` metric.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: by
+  haproxy.clients.canceled:
+    description: Number of data transfers aborted by the client. Corresponds to HAProxy's `cli_abrt` metric
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{cancellations}"
+  haproxy.compression.bypass:
+    description: Number of bytes that bypassed the HTTP compressor (CPU/BW limit). Corresponds to HAProxy's `comp_byp` metric.
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: by
+  haproxy.compression.input:
+    description: Number of HTTP response bytes fed to the compressor. Corresponds to HAProxy's `comp_in` metric.
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: by
+  haproxy.compression.output:
+    description: Number of HTTP response bytes emitted by the compressor. Corresponds to HAProxy's `comp_out` metric.
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: by
+  haproxy.compression.count:
+    description: Number of HTTP responses that were compressed. Corresponds to HAProxy's `comp_rsp` metric.
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{responses}"
+  haproxy.requests.denied:
+    description: Requests denied because of security concerns. Corresponds to HAProxy's `dreq` metric
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{requests}"
+  haproxy.responses.denied:
+    description: Responses denied because of security concerns. Corresponds to HAProxy's `dresp` metric
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{responses}"
+  haproxy.downtime:
+    description:  Total downtime (in seconds). The value for the backend is the downtime for the whole backend, not the sum of the server downtime. Corresponds to HAProxy's `downtime` metric
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: s
+  haproxy.connections.errors:
+    description: Number of requests that encountered an error trying to connect to a backend server. The backend stat is the sum of the stat. Corresponds to HAProxy's `econ` metric
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{errors}"
+  haproxy.requests.errors:
+    description: Cumulative number of request errors. Corresponds to HAProxy's `ereq` metric.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{errors}"
+  haproxy.responses.errors:
+    description: Cumulative number of response errors. Corresponds to HAProxy's `eresp` metric, `srv_abrt` will be counted here also.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{errors}"
+  haproxy.failed_checks:
+    description: Number of failed checks. (Only counts checks failed when the server is up). Corresponds to HAProxy's `chkfail` metric.
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{checks}"
+  haproxy.requests.redispatched:
+    description: Number of times a request was redispatched to another server. Corresponds to HAProxy's `wredis` metric.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{requests}"
+  haproxy.requests.total:
+    description: Total number of HTTP requests received. Corresponds to HAProxy's `req_tot`, `hrsp_1xx`, `hrsp_2xx`, `hrsp_3xx`, `hrsp_4xx`, `hrsp_5xx` and `hrsp_other` metrics.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{requests}"
+    attributes:
+      - status_code
+  haproxy.connections.retries:
+    description: Number of times a connection to a server was retried. Corresponds to HAProxy's `wretr` metric.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{retries}"
+  haproxy.sessions.total:
+    description: Cumulative number of sessions. Corresponds to HAProxy's `stot` metric.
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{sessions}"
+  haproxy.requests.queued:
+    description: Current queued requests. For the backend this reports the number queued without a server assigned. Corresponds to HAProxy's `qcur` metric.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{requests}"
+  haproxy.requests.rate:
+    description: HTTP requests per second over last elapsed second. Corresponds to HAProxy's `req_rate` metric.
+    enabled: true
+    gauge:
+      value_type: double
+      input_type: string
+    unit: "{requests}"
+  haproxy.sessions.average:
+    description: Average total session time in ms over the last 1024 requests. Corresponds to HAProxy's `ttime` metric.
+    enabled: true
+    gauge:
+      value_type: double
+      input_type: string
+    unit: ms
+  haproxy.sessions.rate:
+    description: Number of sessions per second over last elapsed second. Corresponds to HAProxy's `rate` metric.
+    enabled: true
+    gauge:
+      value_type: double
+      input_type: string
+    unit: "{sessions}"

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/httpcheckreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/httpcheckreceiver_metadata.yaml
@@ -1,0 +1,56 @@
+type: httpcheck
+
+status:
+  class: receiver
+  stability:
+    development: [metrics]
+  distributions: [contrib, sumo]
+  warnings: []
+  codeowners:
+    active: [codeboten]
+
+resource_attributes:
+
+attributes:
+  http.url:
+    description: Full HTTP request URL.
+    type: string
+  http.status_code:
+    description: HTTP response status code
+    type: int
+  http.method:
+    description: HTTP request method
+    type: string
+  http.status_class:
+    description: HTTP response status class
+    type: string
+  error.message:
+    description: Error message recorded during check
+    type: string
+
+metrics:
+  httpcheck.status:
+    description: 1 if the check resulted in status_code matching the status_class, otherwise 0.
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    unit: 1
+    attributes: [http.url, http.status_code, http.method, http.status_class]
+  httpcheck.duration:
+    description: Measures the duration of the HTTP check.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: ms
+    attributes: [http.url]
+  httpcheck.error:
+    description: Records errors occurring during HTTP check.
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    unit: "{error}"
+    attributes: [http.url, error.message]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/iisreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/iisreceiver_metadata.yaml
@@ -1,0 +1,135 @@
+type: iis
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [Mrod1598, djaglowski]
+
+resource_attributes:
+  iis.site:
+    description: The site of the web server.
+    enabled: true
+    type: string
+  iis.application_pool:
+    description: The application pool, which is associated with worker processes of one or more applications.
+    enabled: true
+    type: string
+
+attributes:
+  direction:
+    description: The direction data is moving.
+    type: string
+    enum:
+      - sent
+      - received
+  request:
+    description: The type of request sent by a client.
+    type: string
+    enum:
+      - delete
+      - get
+      - head
+      - options
+      - post
+      - put
+      - trace
+
+metrics:
+  iis.request.count:
+    description: Total number of requests of a given type.
+    unit: "{requests}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+    attributes: [ request ]
+  iis.request.rejected:
+    description: Total number of requests rejected.
+    unit: "{requests}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  iis.request.queue.count:
+    description: Current number of requests in the queue.
+    unit: "{requests}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  iis.request.queue.age.max:
+    description: Age of oldest request in the queue.
+    unit: ms
+    gauge:
+      value_type: int
+    enabled: true
+  iis.network.file.count:
+    description: Number of transmitted files.
+    unit: "{files}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+    attributes: [ direction ]
+  iis.network.blocked:
+    description: Number of bytes blocked due to bandwidth throttling.
+    unit: By
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  iis.network.io:
+    description: Total amount of bytes sent and received.
+    unit: By
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+    attributes: [ direction ]
+  iis.connection.attempt.count:
+    description: Total number of attempts to connect to the server.
+    unit: "{attempts}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  iis.connection.active:
+    description: Number of active connections.
+    unit: "{connections}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  iis.connection.anonymous:
+    description: Number of connections established anonymously.
+    unit: "{connections}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  iis.thread.active:
+    description: Current number of active threads.
+    unit: "{threads}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  iis.uptime:
+    description: The amount of time the server has been up.
+    unit: s
+    gauge:
+      value_type: int
+    enabled: true

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/k8sclusterreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/k8sclusterreceiver_metadata.yaml
@@ -1,0 +1,497 @@
+type: k8s_cluster
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+    development: [logs]
+  distributions: [contrib, splunk, observiq, sumo]
+  codeowners:
+    active: [dmitryax, TylerHelmuth, povilasv]
+
+sem_conv_version: 1.18.0
+
+resource_attributes:
+  k8s.namespace.uid:
+    description: The k8s namespace uid.
+    type: string
+    enabled: true
+
+  k8s.namespace.name:
+    description: The k8s namespace name.
+    type: string
+    enabled: true
+
+  k8s.node.uid:
+    description: The k8s node uid.
+    type: string
+    enabled: true
+
+  k8s.node.name:
+    description: The k8s node name.
+    type: string
+    enabled: true
+
+  container.id:
+    description: The container id.
+    type: string
+    enabled: true
+
+  container.image.name:
+    description: The container image name
+    type: string
+    enabled: true
+
+  container.image.tag:
+    description: The container image tag
+    type: string
+    enabled: true
+
+  k8s.container.name:
+    description: The k8s container name
+    type: string
+    enabled: true
+
+  k8s.pod.name:
+    description: The k8s pod name.
+    type: string
+    enabled: true
+
+  k8s.pod.uid:
+    description: The k8s pod uid.
+    type: string
+    enabled: true
+
+  k8s.pod.qos_class:
+    description: "The k8s pod qos class name. One of Guaranteed, Burstable, BestEffort."
+    type: string
+    enabled: false
+
+  k8s.replicaset.name:
+    description: The k8s replicaset name
+    type: string
+    enabled: true
+
+  k8s.replicaset.uid:
+    description: The k8s replicaset uid
+    type: string
+    enabled: true
+
+  k8s.replicationcontroller.name:
+    description: The k8s replicationcontroller name.
+    type: string
+    enabled: true
+
+  k8s.replicationcontroller.uid:
+    description: The k8s replicationcontroller uid.
+    type: string
+    enabled: true
+
+  k8s.resourcequota.uid:
+    description: The k8s resourcequota uid.
+    type: string
+    enabled: true
+
+  k8s.resourcequota.name:
+    description: The k8s resourcequota name.
+    type: string
+    enabled: true
+
+  k8s.statefulset.uid:
+    description: The k8s statefulset uid.
+    type: string
+    enabled: true
+
+  k8s.statefulset.name:
+    description: The k8s statefulset name.
+    type: string
+    enabled: true
+
+  k8s.deployment.uid:
+    description: The UID of the Deployment.
+    type: string
+    enabled: true
+
+  k8s.deployment.name:
+    description: The name of the Deployment.
+    type: string
+    enabled: true
+
+  k8s.cronjob.uid:
+    description: The k8s CronJob uid.
+    type: string
+    enabled: true
+
+  k8s.cronjob.name:
+    description: The k8s CronJob name
+    type: string
+    enabled: true
+
+  k8s.daemonset.name:
+    description: The k8s daemonset name.
+    type: string
+    enabled: true
+
+  k8s.daemonset.uid:
+    description: The k8s daemonset uid.
+    type: string
+    enabled: true
+
+  k8s.hpa.uid:
+    description: The k8s hpa uid.
+    type: string
+    enabled: true
+
+  k8s.hpa.name:
+    description: The k8s hpa name.
+    type: string
+    enabled: true
+
+  k8s.job.name:
+    description: The k8s pod name.
+    type: string
+    enabled: true
+
+  k8s.job.uid:
+    description: The k8s job uid.
+    type: string
+    enabled: true
+
+  k8s.kubelet.version:
+    description: The version of Kubelet running on the node.
+    type: string
+    enabled: false
+
+  k8s.kubeproxy.version:
+    description: The version of Kube Proxy running on the node.
+    type: string
+    enabled: false
+
+  openshift.clusterquota.uid:
+    description: The k8s ClusterResourceQuota uid.
+    type: string
+    enabled: true
+
+  openshift.clusterquota.name:
+    description: The k8s ClusterResourceQuota name.
+    type: string
+    enabled: true
+
+attributes:
+  k8s.namespace.name:
+    description: The k8s namespace name.
+    type: string
+    enabled: true
+  resource:
+    description: the name of the resource on which the quota is applied
+    type: string
+    enabled: true
+  condition:
+    description: "the name of Kubernetes Node condition. Example: Ready, Memory, PID, DiskPressure"
+    type: string
+    enabled: true
+
+metrics:
+  k8s.container.cpu_request:
+    enabled: true
+    description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+    unit: "{cpu}"
+    gauge:
+      value_type: double
+  k8s.container.cpu_limit:
+    enabled: true
+    description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+    unit: "{cpu}"
+    gauge:
+      value_type: double
+  k8s.container.memory_request:
+    enabled: true
+    description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+    unit: "By"
+    gauge:
+      value_type: int
+  k8s.container.memory_limit:
+    enabled: true
+    description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+    unit: "By"
+    gauge:
+      value_type: int
+  k8s.container.storage_request:
+    enabled: true
+    description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+    unit: "By"
+    gauge:
+      value_type: int
+  k8s.container.storage_limit:
+    enabled: true
+    description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+    unit: "By"
+    gauge:
+      value_type: int
+  k8s.container.ephemeralstorage_request:
+    enabled: true
+    description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+    unit: "By"
+    gauge:
+      value_type: int
+  k8s.container.ephemeralstorage_limit:
+    enabled: true
+    description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+    unit: "By"
+    gauge:
+      value_type: int
+  k8s.container.restarts:
+    enabled: true
+    description: How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.
+    unit: "{restart}"
+    gauge:
+      value_type: int
+  k8s.container.ready:
+    enabled: true
+    description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
+    unit: ""
+    gauge:
+      value_type: int
+
+  k8s.pod.phase:
+    enabled: true
+    description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
+    unit: ""
+    gauge:
+      value_type: int
+  k8s.pod.status_reason:
+    enabled: false
+    description: Current status reason of the pod (1 - Evicted, 2 - NodeAffinity, 3 - NodeLost, 4 - Shutdown, 5 - UnexpectedAdmissionError, 6 - Unknown)
+    unit: ""
+    gauge:
+      value_type: int
+
+  k8s.deployment.desired:
+    enabled: true
+    description: Number of desired pods in this deployment
+    unit: "{pod}"
+    gauge:
+      value_type: int
+  k8s.deployment.available:
+    enabled: true
+    description: Total number of available pods (ready for at least minReadySeconds) targeted by this deployment
+    unit: "{pod}"
+    gauge:
+     value_type: int
+
+  k8s.cronjob.active_jobs:
+    enabled: true
+    description: The number of actively running jobs for a cronjob
+    unit: "{job}"
+    gauge:
+      value_type: int
+
+  k8s.daemonset.current_scheduled_nodes:
+    enabled: true
+    description: Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod
+    unit: "{node}"
+    gauge:
+      value_type: int
+  k8s.daemonset.desired_scheduled_nodes:
+    enabled: true
+    description: Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)
+    unit: "{node}"
+    gauge:
+      value_type: int
+  k8s.daemonset.misscheduled_nodes:
+    enabled: true
+    description: Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod
+    unit: "{node}"
+    gauge:
+      value_type: int
+  k8s.daemonset.ready_nodes:
+    enabled: true
+    description: Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready
+    unit: "{node}"
+    gauge:
+      value_type: int
+
+  k8s.hpa.max_replicas:
+    enabled: true
+    description: Maximum number of replicas to which the autoscaler can scale up.
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  k8s.hpa.min_replicas:
+    enabled: true
+    description: Minimum number of replicas to which the autoscaler can scale up.
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  k8s.hpa.current_replicas:
+    enabled: true
+    description: Current number of pod replicas managed by this autoscaler.
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  k8s.hpa.desired_replicas:
+    enabled: true
+    description: Desired number of pod replicas managed by this autoscaler.
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  k8s.job.active_pods:
+    enabled: true
+    description: The number of actively running pods for a job
+    unit: "{pod}"
+    gauge:
+      value_type: int
+  k8s.job.desired_successful_pods:
+    enabled: true
+    description: The desired number of successfully finished pods the job should be run with
+    unit: "{pod}"
+    gauge:
+      value_type: int
+  k8s.job.failed_pods:
+    enabled: true
+    description: The number of pods which reached phase Failed for a job
+    unit: "{pod}"
+    gauge:
+      value_type: int
+  k8s.job.max_parallel_pods:
+    enabled: true
+    description: The max desired number of pods the job should run at any given time
+    unit: "{pod}"
+    gauge:
+      value_type: int
+  k8s.job.successful_pods:
+    enabled: true
+    description: The number of pods which reached phase Succeeded for a job
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  k8s.namespace.phase:
+    enabled: true
+    description: The current phase of namespaces (1 for active and 0 for terminating)
+    unit: ""
+    gauge:
+      value_type: int
+
+  k8s.replicaset.desired:
+    enabled: true
+    description: Number of desired pods in this replicaset
+    unit: "{pod}"
+    gauge:
+      value_type: int
+  k8s.replicaset.available:
+    enabled: true
+    description: Total number of available pods (ready for at least minReadySeconds) targeted by this replicaset
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  k8s.replication_controller.desired:
+    enabled: true
+    description: Number of desired pods in this replication_controller
+    unit: "{pod}"
+    gauge:
+      value_type: int
+  k8s.replication_controller.available:
+    enabled: true
+    description: Total number of available pods (ready for at least minReadySeconds) targeted by this replication_controller
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  k8s.resource_quota.hard_limit:
+    enabled: true
+    description: The upper limit for a particular resource in a specific namespace. Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores
+    unit: "{resource}"
+    gauge:
+      value_type: int
+    attributes:
+      - resource
+  k8s.resource_quota.used:
+    enabled: true
+    description: The usage for a particular resource in a specific namespace. Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores
+    unit: "{resource}"
+    gauge:
+      value_type: int
+    attributes:
+      - resource
+
+  k8s.statefulset.desired_pods:
+    enabled: true
+    description: Number of desired pods in the stateful set (the `spec.replicas` field)
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  k8s.statefulset.ready_pods:
+    enabled: true
+    description: Number of pods created by the stateful set that have the `Ready` condition
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  k8s.statefulset.current_pods:
+    enabled: true
+    description: The number of pods created by the StatefulSet controller from the StatefulSet version
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  k8s.statefulset.updated_pods:
+    enabled: true
+    description: Number of pods created by the StatefulSet controller from the StatefulSet version
+    unit: "{pod}"
+    gauge:
+      value_type: int
+
+  openshift.clusterquota.limit:
+    enabled: true
+    description: The configured upper limit for a particular resource.
+    unit: "{resource}"
+    gauge:
+      value_type: int
+    attributes:
+      - resource
+  openshift.clusterquota.used:
+    enabled: true
+    description: The usage for a particular resource with a configured limit.
+    unit: "{resource}"
+    gauge:
+      value_type: int
+    attributes:
+      - resource
+  openshift.appliedclusterquota.limit:
+    enabled: true
+    description: The upper limit for a particular resource in a specific namespace.
+    unit: "{resource}"
+    gauge:
+      value_type: int
+    attributes:
+      - k8s.namespace.name
+      - resource
+  openshift.appliedclusterquota.used:
+    enabled: true
+    description: The usage for a particular resource in a specific namespace.
+    unit: "{resource}"
+    gauge:
+      value_type: int
+    attributes:
+      - k8s.namespace.name
+      - resource
+  k8s.node.condition:
+    enabled: false
+    description: The condition of a particular Node.
+    unit: "{condition}"
+    gauge:
+      value_type: int
+    attributes:
+      - condition
+  # k8s.node.condition_* metrics (k8s.node.condition_ready, k8s.node.condition_memory_pressure, etc) are controlled 
+  # by node_conditions_to_report config option. By default, only k8s.node.condition_ready is enabled.
+
+  # k8s.node.allocatable_* metrics (k8s.node.allocatable_cpu, k8s.node.allocatable_memory, etc) are controlled
+  # by allocatable_types_to_report config option. By default, none of them are reported.

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/kafkametricsreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/kafkametricsreceiver_metadata.yaml
@@ -1,0 +1,111 @@
+type: kafkametrics
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, splunk, sumo]
+  codeowners:
+    active: [dmitryax]
+
+attributes:
+  topic:
+    description: The ID (integer) of a topic
+    type: string
+  partition:
+    description: The number (integer) of the partition
+    type: int
+  group:
+    description: The ID (string) of a consumer group
+    type: string
+
+metrics:
+  #  brokers scraper
+  kafka.brokers:
+    enabled: true
+    description: Number of brokers in the cluster.
+    unit: "{brokers}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+  #  topics scraper
+  kafka.topic.partitions:
+    enabled: true
+    description: Number of partitions in topic.
+    unit: "{partitions}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [topic]
+  kafka.partition.current_offset:
+    enabled: true
+    description: Current offset of partition of topic.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [topic, partition]
+  kafka.partition.oldest_offset:
+    enabled: true
+    description: Oldest offset of partition of topic
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [topic, partition]
+  kafka.partition.replicas:
+    enabled: true
+    description: Number of replicas for partition of topic
+    unit: "{replicas}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [topic, partition]
+  kafka.partition.replicas_in_sync:
+    enabled: true
+    description: Number of synchronized replicas of partition
+    unit: "{replicas}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [topic, partition]
+  #  consumers scraper
+  kafka.consumer_group.members:
+    enabled: true
+    description: Count of members in the consumer group
+    unit: "{members}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [group]
+  kafka.consumer_group.offset:
+    enabled: true
+    description: Current offset of the consumer group at partition of topic
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [group, topic, partition]
+  kafka.consumer_group.offset_sum:
+    enabled: true
+    description: Sum of consumer group offset across partitions of topic
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [group, topic]
+  kafka.consumer_group.lag:
+    enabled: true
+    description: Current approximate lag of consumer group at partition of topic
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [group, topic, partition]
+  kafka.consumer_group.lag_sum:
+    enabled: true
+    description: Current approximate sum of consumer group lag across all partitions of topic
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [group, topic]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/kubeletstatsreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/kubeletstatsreceiver_metadata.yaml
@@ -1,0 +1,474 @@
+type: kubeletstats
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, splunk, sumo]
+  codeowners:
+    active: [dmitryax, TylerHelmuth]
+
+resource_attributes:
+  k8s.node.name:
+    description: "The name of the Node"
+    enabled: true
+    type: string
+  k8s.pod.uid:
+    description: "The UID of the Pod"
+    enabled: true
+    type: string
+  k8s.pod.name:
+    description: "The name of the Pod"
+    enabled: true
+    type: string
+  k8s.namespace.name:
+    description: "The name of the namespace that the pod is running in"
+    enabled: true
+    type: string
+  k8s.container.name:
+    description: "Container name used by container runtime"
+    enabled: true
+    type: string
+  container.id:
+    description: "Container id used to identify container"
+    enabled: true
+    type: string
+  k8s.volume.name:
+    description: "The name of the Volume"
+    enabled: true
+    type: string
+  k8s.volume.type:
+    description: "The type of the Volume"
+    enabled: true
+    type: string
+  k8s.persistentvolumeclaim.name:
+    description: "The name of the Persistent Volume Claim"
+    enabled: true
+    type: string
+  aws.volume.id:
+    description: "The id of the AWS Volume"
+    enabled: true
+    type: string
+  fs.type:
+    description: "The filesystem type of the Volume"
+    enabled: true
+    type: string
+  partition:
+    description: "The partition in the Volume"
+    enabled: true
+    type: string
+  gce.pd.name:
+    description: "The name of the persistent disk in GCE"
+    enabled: true
+    type: string
+  glusterfs.endpoints.name:
+    description: "The endpoint name that details Glusterfs topology"
+    enabled: true
+    type: string
+  glusterfs.path:
+    description: "Glusterfs volume path"
+    enabled: true
+    type: string
+
+attributes:
+  interface:
+    description: Name of the network interface.
+    type: string
+
+  direction:
+    description: Direction of flow of bytes/operations (receive or transmit).
+    type: string
+    enum: [receive, transmit]
+
+metrics:
+  k8s.node.cpu.utilization:
+    enabled: true
+    description: "Node CPU utilization"
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: []
+  k8s.node.cpu.time:
+    enabled: true
+    description: "Node CPU time"
+    unit: s
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  k8s.node.memory.available:
+    enabled: true
+    description: "Node memory available"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.node.memory.usage:
+    enabled: true
+    description: "Node memory usage"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.node.memory.rss:
+    enabled: true
+    description: "Node memory rss"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.node.memory.working_set:
+    enabled: true
+    description: "Node memory working_set"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.node.memory.page_faults:
+    enabled: true
+    description: "Node memory page_faults"
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.node.memory.major_page_faults:
+    enabled: true
+    description: "Node memory major_page_faults"
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.node.filesystem.available:
+    enabled: true
+    description: "Node filesystem available"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.node.filesystem.capacity:
+    enabled: true
+    description: "Node filesystem capacity"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.node.filesystem.usage:
+    enabled: true
+    description: "Node filesystem usage"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.node.network.io:
+    enabled: true
+    description: "Node network IO"
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: ["interface", "direction"]
+  k8s.node.network.errors:
+    enabled: true
+    description: "Node network errors"
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: ["interface", "direction"]
+  k8s.node.uptime:
+    enabled: false
+    description: "The time since the node started"
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  k8s.pod.cpu.utilization:
+    enabled: true
+    description: "Pod CPU utilization"
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [ ]
+  k8s.pod.cpu.time:
+    enabled: true
+    description: "Pod CPU time"
+    unit: s
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [ ]
+  k8s.pod.memory.available:
+    enabled: true
+    description: "Pod memory available"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.pod.memory.usage:
+    enabled: true
+    description: "Pod memory usage"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.pod.cpu_limit_utilization:
+    enabled: false
+    description: "Pod cpu utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted."
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [ ]
+  k8s.pod.cpu_request_utilization:
+    enabled: false
+    description: "Pod cpu utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted."
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [ ]
+  k8s.pod.memory_limit_utilization:
+    enabled: false
+    description: "Pod memory utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted."
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [ ]
+  k8s.pod.memory_request_utilization:
+    enabled: false
+    description: "Pod memory utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted."
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [ ]
+  k8s.pod.memory.rss:
+    enabled: true
+    description: "Pod memory rss"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.pod.memory.working_set:
+    enabled: true
+    description: "Pod memory working_set"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.pod.memory.page_faults:
+    enabled: true
+    description: "Pod memory page_faults"
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.pod.memory.major_page_faults:
+    enabled: true
+    description: "Pod memory major_page_faults"
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.pod.filesystem.available:
+    enabled: true
+    description: "Pod filesystem available"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.pod.filesystem.capacity:
+    enabled: true
+    description: "Pod filesystem capacity"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.pod.filesystem.usage:
+    enabled: true
+    description: "Pod filesystem usage"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.pod.network.io:
+    enabled: true
+    description: "Pod network IO"
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: ["interface", "direction"]
+  k8s.pod.network.errors:
+    enabled: true
+    description: "Pod network errors"
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: ["interface", "direction"]
+  k8s.pod.uptime:
+    enabled: false
+    description: "The time since the pod started"
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  container.cpu.utilization:
+    enabled: true
+    description: "Container CPU utilization"
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [ ]
+  container.cpu.time:
+    enabled: true
+    description: "Container CPU time"
+    unit: s
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [ ]
+  container.memory.available:
+    enabled: true
+    description: "Container memory available"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  container.memory.usage:
+    enabled: true
+    description: "Container memory usage"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.container.cpu_limit_utilization:
+    enabled: false
+    description: "Container cpu utilization as a ratio of the container's limits"
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [ ]
+  k8s.container.cpu_request_utilization:
+    enabled: false
+    description: "Container cpu utilization as a ratio of the container's requests"
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [ ]
+  k8s.container.memory_limit_utilization:
+    enabled: false
+    description: "Container memory utilization as a ratio of the container's limits"
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [ ]
+  k8s.container.memory_request_utilization:
+    enabled: false
+    description: "Container memory utilization as a ratio of the container's requests"
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [ ]
+  container.memory.rss:
+    enabled: true
+    description: "Container memory rss"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  container.memory.working_set:
+    enabled: true
+    description: "Container memory working_set"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  container.memory.page_faults:
+    enabled: true
+    description: "Container memory page_faults"
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []
+  container.memory.major_page_faults:
+    enabled: true
+    description: "Container memory major_page_faults"
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []
+  container.filesystem.available:
+    enabled: true
+    description: "Container filesystem available"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  container.filesystem.capacity:
+    enabled: true
+    description: "Container filesystem capacity"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  container.filesystem.usage:
+    enabled: true
+    description: "Container filesystem usage"
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  container.uptime:
+    enabled: false
+    description: "The time since the container started"
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  k8s.volume.available:
+    enabled: true
+    description: "The number of available bytes in the volume."
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.volume.capacity:
+    enabled: true
+    description: "The total capacity in bytes of the volume."
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.volume.inodes:
+    enabled: true
+    description: "The total inodes in the filesystem."
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.volume.inodes.free:
+    enabled: true
+    description: "The free inodes in the filesystem."
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []
+  k8s.volume.inodes.used:
+    enabled: true
+    description: "The inodes used by the filesystem. This may not equal inodes - free because filesystem may share inodes with other filesystems."
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: []

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/memcachedreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/memcachedreceiver_metadata.yaml
@@ -1,0 +1,141 @@
+type: memcached
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski]
+
+attributes:
+  command:
+    description: The type of command.
+    type: string
+    enum:
+    - get
+    - set
+    - flush
+    - touch
+  direction:
+    description: Direction of data flow.
+    type: string
+    enum:
+    - sent
+    - received
+  type:
+    description: Result of cache request.
+    type: string
+    enum:
+    - hit
+    - miss
+  operation:
+    description: The type of operation.
+    type: string
+    enum:
+    - increment
+    - decrement
+    - get
+  state:
+    description: The type of CPU usage.
+    type: string
+    enum:
+    - system
+    - user
+
+metrics:
+  memcached.bytes:
+    enabled: true
+    description: Current number of bytes used by this server to store items.
+    unit: By
+    gauge:
+      value_type: int
+    attributes: []
+  memcached.connections.current:
+    enabled: true
+    description: The current number of open connections.
+    unit: "{connections}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: []
+  memcached.connections.total:
+    enabled: true
+    description: Total number of connections opened since the server started running.
+    unit: "{connections}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  memcached.commands:
+    enabled: true
+    description: Commands executed.
+    unit: "{commands}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [command]
+  memcached.current_items:
+    enabled: true
+    description: Number of items currently stored in the cache.
+    unit: "{items}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: []
+  memcached.evictions:
+    enabled: true
+    description: Cache item evictions.
+    unit: "{evictions}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  memcached.network:
+    enabled: true
+    description: Bytes transferred over the network.
+    unit: by
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [direction]
+  memcached.operations:
+    enabled: true
+    description:  Operation counts.
+    unit: "{operations}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [type,operation]
+  memcached.operation_hit_ratio:
+    enabled: true
+    description: Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0.
+    unit: '%'
+    gauge:
+      value_type: double
+    attributes: [operation]
+  memcached.cpu.usage:
+    enabled: true
+    description: Accumulated user and system time.
+    unit: s
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [state]
+  memcached.threads:
+    enabled: true
+    description: Number of threads used by the memcached instance.
+    unit: "{threads}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: []

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/mongodbatlasreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/mongodbatlasreceiver_metadata.yaml
@@ -1,0 +1,730 @@
+type: mongodbatlas
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics, logs]
+  distributions: [contrib, splunk, observiq, sumo]
+  codeowners:
+    active: [djaglowski, schmikei]
+
+resource_attributes:
+  mongodb_atlas.org_name:
+    description: Organization Name
+    enabled: true
+    type: string
+  mongodb_atlas.project.name:
+    description: Project Name
+    enabled: true
+    type: string
+  mongodb_atlas.project.id:
+    description: Project ID
+    enabled: true
+    type: string
+  mongodb_atlas.host.name:
+    description: Hostname of the process
+    enabled: true
+    type: string
+  mongodb_atlas.user.alias:
+    description: User-friendly hostname of the cluster node
+    enabled: false
+    type: string
+  mongodb_atlas.cluster.name:
+    description: Cluster Name
+    enabled: false
+    type: string
+  mongodb_atlas.region.name:
+    description: Region Name
+    enabled: false
+    type: string
+  mongodb_atlas.provider.name:
+    description: Provider Name
+    enabled: false
+    type: string
+  mongodb_atlas.process.port:
+    description: Port process is bound to
+    enabled: true
+    type: string
+  mongodb_atlas.process.type_name:
+    description: Process type
+    enabled: true
+    type: string
+  mongodb_atlas.process.id:
+    description: ID of the process
+    enabled: true
+    type: string
+  mongodb_atlas.db.name:
+    description: Name of the Database
+    enabled: true
+    type: string
+  mongodb_atlas.disk.partition:
+    description: Name of a disk partition
+    enabled: true
+    type: string
+
+attributes:
+  cpu_state:
+    description: CPU state
+    type: string
+    enum:
+      - kernel
+      - user
+      - nice
+      - iowait
+      - irq
+      - softirq
+      - guest
+      - steal
+  assert_type:
+    description: MongoDB assertion type
+    type: string
+    enum:
+      - regular
+      - warning
+      - msg
+      - user
+  cache_direction:
+    description: Whether read into or written from
+    type: string
+    enum:
+      - read_into
+      - written_from
+  cache_status:
+    description: Cache status
+    type: string
+    enum:
+      - dirty
+      - used
+  ticket_type:
+    description: Type of ticket available
+    type: string
+    enum:
+      - available_reads
+      - available_writes
+  cursor_state:
+    description: Whether cursor is open or timed out
+    type: string
+    enum:
+      - timed_out
+      - open
+  memory_issue_type:
+    description: Type of memory issue encountered
+    type: string
+    enum:
+      - extra_info
+      - global_accesses_not_in_memory
+      - exceptions_thrown
+  global_lock_state:
+    description: Which queue is locked
+    type: string
+    enum:
+      - current_queue_total
+      - current_queue_readers
+      - current_queue_writers
+  btree_counter_type:
+    description: Database index effectiveness
+    type: string
+    enum:
+      - accesses
+      - hits
+      - misses
+  memory_state:
+    description: Memory usage type
+    type: string
+    enum:
+      - resident
+      - virtual
+      - mapped
+      - computed
+      - shared
+      - free
+      - used
+  direction:
+    description: Network traffic direction
+    type: string
+    enum:
+      - receive
+      - transmit
+  storage_status:
+    description: Views on database size
+    type: string
+    enum:
+      - total
+      - data_size
+      - index_size
+      - data_size_wo_system
+  operation:
+    description: Type of database operation
+    type: string
+    enum:
+      - cmd
+      - query
+      - update
+      - delete
+      - getmore
+      - insert
+      - scan_and_order
+  cluster_role:
+    description: Whether process is acting as replica or primary
+    type: string
+    enum:
+      - primary
+      - replica
+  document_status:
+    description: Status of documents in the database
+    type: string
+    enum:
+      - returned
+      - inserted
+      - updated
+      - deleted
+  execution_type:
+    description: Type of command
+    type: string
+    enum:
+      - reads
+      - writes
+      - commands
+  scanned_type:
+    description: Objects or indexes scanned during query
+    type: string
+    enum:
+      - index_items
+      - objects
+  disk_direction:
+    description: Measurement type for disk operation
+    type: string
+    enum:
+      - read
+      - write
+      - total
+  disk_status:
+    description: Disk measurement type
+    type: string
+    enum:
+      - free
+      - used
+  memory_status:
+    description: Memory measurement type
+    type: string
+    enum:
+      - available
+      - buffers
+      - cached
+      - free
+      - shared
+      - used
+  object_type:
+    description: MongoDB object type
+    type: string
+    enum:
+      - collection
+      - index
+      - extent
+      - object
+      - view
+      - storage
+      - data
+  oplog_type:
+    description: Oplog type
+    type: string
+    enum:
+      - slave_lag_master_time
+      - master_time
+      - master_lag_time_diff
+
+metrics:
+  mongodbatlas.process.asserts:
+    enabled: true
+    description: Number of assertions per second
+    extended_documentation: Aggregate of MongoDB Metrics ASSERT_REGULAR, ASSERT_USER, ASSERT_MSG, ASSERT_WARNING
+    unit: "{assertions}/s"
+    attributes: [assert_type]
+    gauge:
+      value_type: double
+  mongodbatlas.process.background_flush:
+    enabled: true
+    description: Amount of data flushed in the background
+    extended_documentation: MongoDB Metric BACKGROUND_FLUSH_AVG
+    unit: 1
+    gauge:
+      value_type: double
+  mongodbatlas.process.cache.io:
+    enabled: true
+    description: Cache throughput (per second)
+    extended_documentation: Aggregate of MongoDB Metrics CACHE_BYTES_READ_INTO, CACHE_BYTES_WRITTEN_FROM
+    unit: By
+    attributes: [cache_direction]
+    gauge:
+      value_type: double
+  mongodbatlas.process.cache.size:
+    enabled: true
+    description: Cache sizes
+    extended_documentation: Aggregate of MongoDB Metrics CACHE_USED_BYTES, CACHE_DIRTY_BYTES
+    unit: By
+    attributes: [cache_status]
+    sum:
+      value_type: double
+      monotonic: false
+      aggregation_temporality: cumulative
+  mongodbatlas.process.connections:
+    enabled: true
+    description: Number of current connections
+    extended_documentation: MongoDB Metric CONNECTIONS
+    unit: "{connections}"
+    sum:
+      value_type: double
+      monotonic: false
+      aggregation_temporality: cumulative
+  mongodbatlas.process.cpu.usage.max:
+    enabled: true
+    description: CPU Usage (%)
+    extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_CPU_KERNEL, MAX_PROCESS_CPU_USER
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.cpu.usage.average:
+    enabled: true
+    description: CPU Usage (%)
+    extended_documentation: Aggregate of MongoDB Metrics PROCESS_CPU_KERNEL, PROCESS_CPU_USER
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.cpu.children.usage.max:
+    enabled: true
+    description: CPU Usage for child processes (%)
+    extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_CPU_CHILDREN_USER, MAX_PROCESS_CPU_CHILDREN_KERNEL
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.cpu.children.usage.average:
+    enabled: true
+    description: CPU Usage for child processes (%)
+    extended_documentation: Aggregate of MongoDB Metrics PROCESS_CPU_CHILDREN_KERNEL, PROCESS_CPU_CHILDREN_USER
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.cpu.children.normalized.usage.max:
+    enabled: true
+    description: CPU Usage for child processes, normalized to pct
+    extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, MAX_PROCESS_NORMALIZED_CPU_CHILDREN_USER
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.cpu.children.normalized.usage.average:
+    enabled: true
+    description: CPU Usage for child processes, normalized to pct
+    extended_documentation: Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, PROCESS_NORMALIZED_CPU_CHILDREN_USER
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.cpu.normalized.usage.max:
+    enabled: true
+    description: CPU Usage, normalized to pct
+    extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_USER, MAX_PROCESS_NORMALIZED_CPU_KERNEL
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.cpu.normalized.usage.average:
+    enabled: true
+    description: CPU Usage, normalized to pct
+    extended_documentation: Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_KERNEL, PROCESS_NORMALIZED_CPU_USER
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.cursors:
+    enabled: true
+    description: Number of cursors
+    extended_documentation: Aggregate of MongoDB Metrics CURSORS_TOTAL_OPEN, CURSORS_TOTAL_TIMED_OUT
+    unit: "{cursors}"
+    attributes: [cursor_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.db.storage:
+    enabled: true
+    description: Storage used by the database
+    extended_documentation: Aggregate of MongoDB Metrics DB_INDEX_SIZE_TOTAL, DB_DATA_SIZE_TOTAL_WO_SYSTEM, DB_STORAGE_TOTAL, DB_DATA_SIZE_TOTAL
+    unit: By
+    attributes: [storage_status]
+    gauge:
+      value_type: double
+  mongodbatlas.process.db.document.rate:
+    enabled: true
+    description: Document access rates
+    extended_documentation: Aggregate of MongoDB Metrics DOCUMENT_METRICS_UPDATED, DOCUMENT_METRICS_DELETED, DOCUMENT_METRICS_RETURNED, DOCUMENT_METRICS_INSERTED
+    unit: "{documents}/s"
+    attributes: [document_status]
+    gauge:
+      value_type: double
+  mongodbatlas.process.global_lock:
+    enabled: true
+    description: Number and status of locks
+    extended_documentation: Aggregate of MongoDB Metrics GLOBAL_LOCK_CURRENT_QUEUE_WRITERS, GLOBAL_LOCK_CURRENT_QUEUE_READERS, GLOBAL_LOCK_CURRENT_QUEUE_TOTAL
+    unit: "{locks}"
+    attributes: [global_lock_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.index.btree_miss_ratio:
+    enabled: true
+    description: Index miss ratio (%)
+    extended_documentation: MongoDB Metric INDEX_COUNTERS_BTREE_MISS_RATIO
+    unit: 1
+    gauge:
+      value_type: double
+  mongodbatlas.process.index.counters:
+    enabled: true
+    description: Indexes
+    extended_documentation: Aggregate of MongoDB Metrics INDEX_COUNTERS_BTREE_MISSES, INDEX_COUNTERS_BTREE_ACCESSES, INDEX_COUNTERS_BTREE_HITS
+    unit: "{indexes}"
+    attributes: [btree_counter_type]
+    gauge:
+      value_type: double
+  mongodbatlas.process.journaling.commits:
+    enabled: true
+    description: Journaling commits
+    extended_documentation: MongoDB Metric JOURNALING_COMMITS_IN_WRITE_LOCK
+    unit: "{commits}"
+    gauge:
+      value_type: double
+  mongodbatlas.process.journaling.data_files:
+    enabled: true
+    description: Data file sizes
+    extended_documentation: MongoDB Metric JOURNALING_WRITE_DATA_FILES_MB
+    unit: MiBy
+    gauge:
+      value_type: double
+  mongodbatlas.process.journaling.written:
+    enabled: true
+    description: Journals written
+    extended_documentation: MongoDB Metric JOURNALING_MB
+    unit: MiBy
+    gauge:
+      value_type: double
+  mongodbatlas.process.memory.usage:
+    enabled: true
+    description: Memory Usage
+    extended_documentation: Aggregate of MongoDB Metrics MEMORY_MAPPED, MEMORY_VIRTUAL, COMPUTED_MEMORY, MEMORY_RESIDENT
+    unit: By
+    attributes: [memory_state]
+    gauge:
+      value_type: double
+  mongodbatlas.process.network.io:
+    enabled: true
+    description: Network IO
+    extended_documentation: Aggregate of MongoDB Metrics NETWORK_BYTES_OUT, NETWORK_BYTES_IN
+    unit: By/s
+    attributes: [direction]
+    gauge:
+      value_type: double
+  mongodbatlas.process.network.requests:
+    enabled: true
+    description: Network requests
+    extended_documentation: MongoDB Metric NETWORK_NUM_REQUESTS
+    unit: "{requests}"
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+  mongodbatlas.process.oplog.time:
+    enabled: true
+    description: Execution time by operation
+    extended_documentation: Aggregate of MongoDB Metrics OPLOG_MASTER_TIME, OPLOG_SLAVE_LAG_MASTER_TIME, OPLOG_MASTER_LAG_TIME_DIFF
+    unit: s
+    attributes: [oplog_type]
+    gauge:
+      value_type: double
+  mongodbatlas.process.oplog.rate:
+    enabled: true
+    description: Execution rate by operation
+    extended_documentation: MongoDB Metric OPLOG_RATE_GB_PER_HOUR
+    unit: GiBy/h
+    gauge:
+      value_type: double
+  mongodbatlas.process.db.operations.rate:
+    enabled: true
+    description: DB Operation Rates
+    extended_documentation: Aggregate of MongoDB Metrics OPCOUNTER_GETMORE, OPERATIONS_SCAN_AND_ORDER, OPCOUNTER_UPDATE, OPCOUNTER_REPL_UPDATE, OPCOUNTER_CMD, OPCOUNTER_DELETE, OPCOUNTER_REPL_DELETE, OPCOUNTER_REPL_CMD, OPCOUNTER_QUERY, OPCOUNTER_REPL_INSERT, OPCOUNTER_INSERT
+    unit: "{operations}/s"
+    attributes: [operation, cluster_role]
+    gauge:
+      value_type: double
+  mongodbatlas.process.db.operations.time:
+    enabled: true
+    description: DB Operation Times
+    extended_documentation: Aggregate of MongoDB Metrics OP_EXECUTION_TIME_WRITES, OP_EXECUTION_TIME_COMMANDS, OP_EXECUTION_TIME_READS
+    unit: ms
+    attributes: [execution_type]
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+  mongodbatlas.process.page_faults:
+    enabled: true
+    description: Page faults
+    extended_documentation: Aggregate of MongoDB Metrics GLOBAL_PAGE_FAULT_EXCEPTIONS_THROWN, EXTRA_INFO_PAGE_FAULTS, GLOBAL_ACCESSES_NOT_IN_MEMORY
+    unit: "{faults}/s"
+    attributes: [memory_issue_type]
+    gauge:
+      value_type: double
+  mongodbatlas.process.db.query_executor.scanned:
+    enabled: true
+    description: Scanned objects
+    extended_documentation: Aggregate of MongoDB Metrics QUERY_EXECUTOR_SCANNED_OBJECTS, QUERY_EXECUTOR_SCANNED
+    attributes: [scanned_type]
+    unit: "{objects}/s"
+    gauge:
+      value_type: double
+  mongodbatlas.process.db.query_targeting.scanned_per_returned:
+    enabled: true
+    description: Scanned objects per returned
+    extended_documentation: Aggregate of MongoDB Metrics QUERY_TARGETING_SCANNED_OBJECTS_PER_RETURNED, QUERY_TARGETING_SCANNED_PER_RETURNED
+    unit: "{scanned}/{returned}"
+    attributes: [scanned_type]
+    gauge:
+      value_type: double
+  mongodbatlas.process.restarts:
+    enabled: true
+    description: Restarts in last hour
+    extended_documentation: Aggregate of MongoDB Metrics RESTARTS_IN_LAST_HOUR
+    unit: "{restarts}/h"
+    gauge:
+      value_type: double
+  mongodbatlas.system.paging.usage.max:
+    enabled: true
+    description: Swap usage
+    extended_documentation: Aggregate of MongoDB Metrics MAX_SWAP_USAGE_FREE, MAX_SWAP_USAGE_USED
+    unit: KiBy
+    attributes: [memory_state]
+    gauge:
+      value_type: double
+  mongodbatlas.system.paging.usage.average:
+    enabled: true
+    description: Swap usage
+    extended_documentation: Aggregate of MongoDB Metrics SWAP_USAGE_FREE, SWAP_USAGE_USED
+    unit: KiBy
+    attributes: [memory_state]
+    gauge:
+      value_type: double
+  mongodbatlas.system.paging.io.max:
+    enabled: true
+    description: Swap IO
+    extended_documentation: Aggregate of MongoDB Metrics MAX_SWAP_IO_IN, MAX_SWAP_IO_OUT
+    unit: "{pages}/s"
+    attributes: [direction]
+    gauge:
+      value_type: double
+  mongodbatlas.system.paging.io.average:
+    enabled: true
+    description: Swap IO
+    extended_documentation: Aggregate of MongoDB Metrics SWAP_IO_IN, SWAP_IO_OUT
+    unit: "{pages}/s"
+    attributes: [direction]
+    gauge:
+      value_type: double
+  mongodbatlas.system.cpu.usage.max:
+    enabled: true
+    description: System CPU Usage (%)
+    extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_CPU_SOFTIRQ, MAX_SYSTEM_CPU_IRQ, MAX_SYSTEM_CPU_GUEST, MAX_SYSTEM_CPU_IOWAIT, MAX_SYSTEM_CPU_NICE, MAX_SYSTEM_CPU_KERNEL, MAX_SYSTEM_CPU_USER, MAX_SYSTEM_CPU_STEAL
+    attributes: [cpu_state]
+    unit: 1
+    gauge:
+      value_type: double
+  mongodbatlas.system.cpu.usage.average:
+    enabled: true
+    description: System CPU Usage (%)
+    extended_documentation: Aggregate of MongoDB Metrics SYSTEM_CPU_USER, SYSTEM_CPU_GUEST, SYSTEM_CPU_SOFTIRQ, SYSTEM_CPU_IRQ, SYSTEM_CPU_KERNEL, SYSTEM_CPU_IOWAIT, SYSTEM_CPU_NICE, SYSTEM_CPU_STEAL
+    attributes: [cpu_state]
+    unit: 1
+    gauge:
+      value_type: double
+  mongodbatlas.system.memory.usage.max:
+    enabled: true
+    description: System Memory Usage
+    extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_MEMORY_CACHED, MAX_SYSTEM_MEMORY_AVAILABLE, MAX_SYSTEM_MEMORY_USED, MAX_SYSTEM_MEMORY_BUFFERS, MAX_SYSTEM_MEMORY_FREE, MAX_SYSTEM_MEMORY_SHARED
+    unit: KiBy
+    attributes: [memory_status]
+    gauge:
+      value_type: double
+  mongodbatlas.system.memory.usage.average:
+    enabled: true
+    description: System Memory Usage
+    extended_documentation: Aggregate of MongoDB Metrics SYSTEM_MEMORY_AVAILABLE, SYSTEM_MEMORY_BUFFERS, SYSTEM_MEMORY_USED, SYSTEM_MEMORY_CACHED, SYSTEM_MEMORY_SHARED, SYSTEM_MEMORY_FREE
+    unit: KiBy
+    attributes: [memory_status]
+    gauge:
+      value_type: double
+  mongodbatlas.system.network.io.max:
+    enabled: true
+    description: System Network IO
+    extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_NETWORK_OUT, MAX_SYSTEM_NETWORK_IN
+    unit: By/s
+    attributes: [direction]
+    gauge:
+      value_type: double
+  mongodbatlas.system.network.io.average:
+    enabled: true
+    description: System Network IO
+    extended_documentation: Aggregate of MongoDB Metrics SYSTEM_NETWORK_IN, SYSTEM_NETWORK_OUT
+    unit: By/s
+    attributes: [direction]
+    gauge:
+      value_type: double
+  mongodbatlas.system.cpu.normalized.usage.max:
+    enabled: true
+    description: System CPU Normalized to pct
+    extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_NORMALIZED_CPU_USER, MAX_SYSTEM_NORMALIZED_CPU_NICE, MAX_SYSTEM_NORMALIZED_CPU_IOWAIT, MAX_SYSTEM_NORMALIZED_CPU_SOFTIRQ, MAX_SYSTEM_NORMALIZED_CPU_STEAL, MAX_SYSTEM_NORMALIZED_CPU_KERNEL, MAX_SYSTEM_NORMALIZED_CPU_GUEST, MAX_SYSTEM_NORMALIZED_CPU_IRQ
+    attributes: [cpu_state]
+    unit: 1
+    gauge:
+      value_type: double
+  mongodbatlas.system.cpu.normalized.usage.average:
+    enabled: true
+    description: System CPU Normalized to pct
+    extended_documentation: Aggregate of MongoDB Metrics SYSTEM_NORMALIZED_CPU_IOWAIT, SYSTEM_NORMALIZED_CPU_GUEST, SYSTEM_NORMALIZED_CPU_IRQ, SYSTEM_NORMALIZED_CPU_KERNEL, SYSTEM_NORMALIZED_CPU_STEAL, SYSTEM_NORMALIZED_CPU_SOFTIRQ, SYSTEM_NORMALIZED_CPU_NICE, SYSTEM_NORMALIZED_CPU_USER
+    attributes: [cpu_state]
+    unit: 1
+    gauge:
+      value_type: double
+  mongodbatlas.process.tickets:
+    enabled: true
+    description: Tickets
+    extended_documentation: Aggregate of MongoDB Metrics TICKETS_AVAILABLE_WRITE, TICKETS_AVAILABLE_READS
+    unit: "{tickets}"
+    attributes: [ticket_type]
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.iops.max:
+    enabled: true
+    description: Disk partition iops
+    extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_IOPS_WRITE, MAX_DISK_PARTITION_IOPS_TOTAL, MAX_DISK_PARTITION_IOPS_READ
+    unit: "{ops}/s"
+    attributes: [disk_direction]
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.iops.average:
+    enabled: true
+    description: Disk partition iops
+    extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_IOPS_READ, DISK_PARTITION_IOPS_WRITE, DISK_PARTITION_IOPS_TOTAL
+    unit: "{ops}/s"
+    attributes: [disk_direction]
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.usage.max:
+    enabled: true
+    description: Disk partition usage (%)
+    extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PARTITION_SPACE_PERCENT_FREE
+    unit: 1
+    attributes: [disk_status]
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.usage.average:
+    enabled: true
+    description: Disk partition usage (%)
+    extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
+    unit: 1
+    attributes: [disk_status]
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.utilization.max:
+    enabled: true
+    description: The maximum percentage of time during which requests are being issued to and serviced by the partition.
+    extended_documentation: MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
+    unit: 1
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.utilization.average:
+    enabled: true
+    description: The percentage of time during which requests are being issued to and serviced by the partition.
+    extended_documentation: MongoDB Metrics DISK_PARTITION_UTILIZATION
+    unit: 1
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.latency.max:
+    enabled: true
+    description: Disk partition latency
+    extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_LATENCY_WRITE, MAX_DISK_PARTITION_LATENCY_READ
+    unit: ms
+    attributes: [disk_direction]
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.latency.average:
+    enabled: true
+    description: Disk partition latency
+    extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_LATENCY_WRITE, DISK_PARTITION_LATENCY_READ
+    unit: ms
+    attributes: [disk_direction]
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.space.max:
+    enabled: true
+    description: Disk partition space
+    extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USED
+    unit: By
+    attributes: [disk_status]
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.space.average:
+    enabled: true
+    description: Disk partition space
+    extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USED
+    unit: By
+    attributes: [disk_status]
+    gauge:
+      value_type: double
+  mongodbatlas.db.size:
+    enabled: true
+    description: Database feature size
+    extended_documentation: Aggregate of MongoDB Metrics DATABASE_DATA_SIZE, DATABASE_STORAGE_SIZE, DATABASE_INDEX_SIZE, DATABASE_AVERAGE_OBJECT_SIZE
+    unit: By
+    attributes: [object_type]
+    gauge:
+      value_type: double
+  mongodbatlas.db.counts:
+    enabled: true
+    description: Database feature size
+    extended_documentation: Aggregate of MongoDB Metrics DATABASE_EXTENT_COUNT, DATABASE_VIEW_COUNT, DATABASE_COLLECTION_COUNT, DATABASE_OBJECT_COUNT, DATABASE_INDEX_COUNT
+    unit: "{objects}"
+    attributes: [object_type]
+    gauge:
+      value_type: double
+  mongodbatlas.system.fts.memory.usage:
+    enabled: true
+    description: Full-text search
+    extended_documentation: Aggregate of MongoDB Metrics FTS_MEMORY_MAPPED, FTS_PROCESS_SHARED_MEMORY, FTS_PROCESS_RESIDENT_MEMORY, FTS_PROCESS_VIRTUAL_MEMORY
+    unit: MiBy
+    attributes: [memory_state]
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+  mongodbatlas.system.fts.disk.used:
+    enabled: true
+    description: Full text search disk usage
+    extended_documentation: MongoDB Metric FTS_DISK_USAGE
+    unit: By
+    gauge:
+      value_type: double
+  mongodbatlas.system.fts.cpu.usage:
+    enabled: true
+    description: Full-text search (%)
+    extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double
+  mongodbatlas.system.fts.cpu.normalized.usage:
+    enabled: true
+    description: Full text search disk usage (%)
+    extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_NORMALIZED_CPU_USER, FTS_PROCESS_NORMALIZED_CPU_KERNEL
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/mongodbreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/mongodbreceiver_metadata.yaml
@@ -1,0 +1,354 @@
+type: mongodb
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski, schmikei]
+
+resource_attributes:
+  database:
+    description: The name of a database.
+    enabled: true
+    type: string
+
+attributes:
+  database:
+    description: The name of a database.
+    type: string
+  collection:
+    description: The name of a collection.
+    type: string
+  memory_type:
+    name_override: type
+    description: The type of memory used.
+    type: string
+    enum:
+      - resident
+      - virtual
+  operation:
+    description: The MongoDB operation being counted.
+    type: string
+    enum:
+      - insert
+      - query
+      - update
+      - delete
+      - getmore
+      - command
+  operation_latency:
+    name_override: operation
+    description: The MongoDB operation with regards to latency
+    type: string
+    enum:
+      - read
+      - write
+      - command
+  connection_type:
+    name_override: type
+    description: The status of the connection.
+    type: string
+    enum:
+      - active
+      - available
+      - current
+  type:
+    description: The result of a cache request.
+    type: string
+    enum:
+      - hit
+      - miss
+  lock_type:
+    description: The Resource over which the Lock controls access
+    type: string
+    enum:
+      - parallel_batch_write_mode
+      - replication_state_transition
+      - global
+      - database
+      - collection
+      - mutex
+      - metadata
+      - oplog
+  lock_mode:
+    description: The mode of Lock which denotes the degree of access
+    type: string
+    enum:
+      - shared
+      - exclusive
+      - intent_shared
+      - intent_exclusive
+
+metrics:
+  mongodb.cache.operations:
+    description: The number of cache operations of the instance.
+    unit: "{operations}"
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: true
+    attributes: [type]
+  mongodb.collection.count:
+    description: The number of collections.
+    unit: "{collections}"
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: false
+    attributes: [database]
+  mongodb.data.size:
+    description: The size of the collection. Data compression does not affect this value.
+    unit: By
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: false
+    attributes: [database]
+  mongodb.connection.count:
+    description: The number of connections.
+    unit: "{connections}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: [database, connection_type]
+  mongodb.extent.count:
+    description: The number of extents.
+    unit: "{extents}"
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: false
+    attributes: [database]
+  mongodb.global_lock.time:
+    description: The time the global lock has been held.
+    unit: ms
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: true
+    attributes: []
+  mongodb.index.count:
+    description: The number of indexes.
+    unit: "{indexes}"
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: false
+    attributes: [database]
+  mongodb.index.size:
+    description: Sum of the space allocated to all indexes in the database, including free index space.
+    unit: By
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: false
+    attributes: [database]
+  mongodb.memory.usage:
+    description: The amount of memory used.
+    unit: By
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: false
+    attributes: [database, memory_type]
+  mongodb.object.count:
+    description: The number of objects.
+    unit: "{objects}"
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: false
+    attributes: [database]
+  mongodb.operation.latency.time:
+    description: The latency of operations.
+    unit: us
+    enabled: false
+    gauge:
+      value_type: int
+    attributes: [ operation_latency ]
+  mongodb.operation.count:
+    description: The number of operations executed.
+    unit: "{operations}"
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: true
+    attributes: [operation]
+  mongodb.operation.repl.count:
+    description: The number of replicated operations executed.
+    unit: "{operations}"
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: true
+    attributes: [ operation ]
+  mongodb.storage.size:
+    description: The total amount of storage allocated to this collection.
+    extended_documentation: If collection data is compressed it reflects the compressed size.
+    unit: By
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      value_type: int
+      monotonic: true
+    attributes: [database]
+  mongodb.database.count:
+    description: The number of existing databases.
+    unit: "{databases}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.index.access.count:
+    description: The number of times an index has been accessed.
+    unit: "{accesses}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: [database, collection]
+  mongodb.document.operation.count:
+    description: The number of document operations executed.
+    unit: "{documents}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: [database, operation]
+  mongodb.network.io.receive:
+    description: The number of bytes received.
+    unit: By
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.network.io.transmit:
+    description: The number of by transmitted.
+    unit: By
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.network.request.count:
+    description: The number of requests received by the server.
+    unit: "{requests}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.operation.time:
+    description: The total time spent performing operations.
+    unit: ms
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+    attributes: [operation]
+  mongodb.session.count:
+    description: The total number of active sessions.
+    unit: "{sessions}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.cursor.count:
+    description: The number of open cursors maintained for clients.
+    unit: "{cursors}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.cursor.timeout.count:
+    description: The number of cursors that have timed out.
+    unit: "{cursors}"
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.lock.acquire.count:
+    description: Number of times the lock was acquired in the specified mode.
+    unit: "{count}"
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+    attributes: [database, lock_type, lock_mode]
+  mongodb.lock.acquire.wait_count:
+    description: Number of times the lock acquisitions encountered waits because the locks were held in a conflicting mode.
+    unit: "{count}"
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+    attributes: [database, lock_type, lock_mode]
+  mongodb.lock.acquire.time:
+    description: Cumulative wait time for the lock acquisitions.
+    unit: "microseconds"
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+    attributes: [database, lock_type, lock_mode]
+  mongodb.lock.deadlock.count:
+    description: Number of times the lock acquisitions encountered deadlocks.
+    unit: "{count}"
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+    attributes: [database, lock_type, lock_mode]
+  mongodb.health:
+    enabled: false
+    description: The health status of the server.
+    extended_documentation:
+      A value of '1' indicates healthy.
+      A value of '0' indicates unhealthy.
+    unit: 1
+    gauge:
+      value_type: int
+    attributes: [ ]
+  mongodb.uptime:
+    enabled: false
+    description: The amount of time that the server has been running.
+    unit: ms
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [ ]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/mysqlreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/mysqlreceiver_metadata.yaml
@@ -1,0 +1,581 @@
+type: mysql
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski]
+
+resource_attributes:
+  mysql.instance.endpoint:
+    description: Endpoint of the MySQL instance.
+    enabled: true
+    type: string
+
+attributes:
+  buffer_pool_pages:
+    name_override: kind
+    description: The buffer pool pages types.
+    type: string
+    enum: [data, free, misc]
+  buffer_pool_data:
+    name_override: status
+    description: The status of buffer pool data.
+    type: string
+    enum: [dirty, clean]
+  buffer_pool_operations:
+    name_override: operation
+    description: The buffer pool operations types.
+    type: string
+    enum: [read_ahead_rnd, read_ahead, read_ahead_evicted, read_requests, reads, wait_free, write_requests]
+  prepared_statements_command:
+    name_override: command
+    description: The prepare statement command types.
+    type: string
+    enum: [execute, close, fetch, prepare, reset, send_long_data]
+  command:
+    description: The command types.
+    type: string
+    enum: [delete, insert, select, update]
+  connection_error:
+    name_override: error
+    description: The connection error type.
+    type: string
+    enum: [accept, internal, max_connections, peer_address, select, tcpwrap, aborted, aborted_clients, locked]
+  handler:
+    name_override: kind
+    description: The handler types.
+    type: string
+    enum: [commit, delete, discover, external_lock, mrr_init, prepare, read_first, read_key, read_last, read_next, read_prev, read_rnd, read_rnd_next, rollback, savepoint, savepoint_rollback, update, write]
+  double_writes:
+    name_override: kind
+    description: The doublewrite types.
+    type: string
+    enum: [pages_written, writes]
+  log_operations:
+    name_override: operation
+    description: The log operation types.
+    type: string
+    enum: [waits, write_requests, writes]
+  operations:
+    name_override: operation
+    description: The operation types.
+    type: string
+    enum: [fsyncs, reads, writes]
+  page_operations:
+    name_override: operation
+    description: The page operation types.
+    type: string
+    enum: [created, read, written]
+  row_locks:
+    name_override: kind
+    description: The row lock type.
+    type: string
+    enum: [waits, time]
+  row_operations:
+    name_override: operation
+    description: The row operation type.
+    type: string
+    enum: [deleted, inserted, read, updated]
+  locks:
+    name_override: kind
+    description: The table locks type.
+    type: string
+    enum: [immediate, waited]
+  sorts:
+    name_override: kind
+    description: The sort count type.
+    type: string
+    enum: [merge_passes, range, rows, scan]
+  threads:
+    name_override: kind
+    description: The thread count type.
+    type: string
+    enum: [cached, connected, created, running]
+  schema:
+    description: The schema of the object.
+    type: string
+  io_waits_operations:
+    name_override: operation
+    description: The io_waits operation type.
+    type: string
+    enum: [delete, fetch, insert, update]
+  table_name:
+    name_override: table
+    type: string
+    description: Table name for event or process.
+  index_name:
+    name_override: index
+    type: string
+    description: The name of the index.
+  direction:
+    name_override: kind
+    description: The name of the transmission direction.
+    type: string
+    enum: [received, sent]
+  digest:
+    description: Digest.
+    type: string
+  digest_text:
+    description: Text before digestion.
+    type: string
+  event_state:
+    name_override: kind
+    description: Possible event states.
+    type: string
+    enum: [errors, warnings, rows_affected, rows_sent, rows_examined, created_tmp_disk_tables, created_tmp_tables, sort_merge_passes, sort_rows, no_index_used]
+  opened_resources:
+    name_override: kind
+    description: The kind of the resource.
+    type: string
+    enum: [file, table_definition, table]
+  join_kind:
+    name_override: kind
+    description: The kind of join.
+    type: string
+    enum: [full, full_range, range, range_check, scan]
+  read_lock_type:
+    name_override: kind
+    description: Read operation types.
+    type: string
+    enum: [normal, with_shared_locks, high_priority, no_insert, external]
+  write_lock_type:
+    name_override: kind
+    description: Write operation types.
+    type: string
+    enum: [allow_write, concurrent_insert, low_priority, normal, external]
+  tmp_resource:
+    name_override: resource
+    description: The kind of temporary resources.
+    type: string
+    enum: [disk_tables, files, tables]
+  mysqlx_threads:
+    name_override: kind
+    description: The worker thread count kind.
+    type: string
+    enum: [available, active]
+  connection_status:
+    name_override: status
+    description: The connection status.
+    type: string
+    enum: [accepted, closed, rejected]
+  cache_status:
+    name_override: status
+    description: The status of cache access.
+    type: string
+    enum: [hit, miss, overflow]
+
+metrics:
+  mysql.buffer_pool.pages:
+    enabled: true
+    description: The number of pages in the InnoDB buffer pool.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [buffer_pool_pages]
+  mysql.buffer_pool.data_pages:
+    enabled: true
+    description: The number of data pages in the InnoDB buffer pool.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [buffer_pool_data]
+  mysql.buffer_pool.page_flushes:
+    enabled: true
+    description: The number of requests to flush pages from the InnoDB buffer pool.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  mysql.buffer_pool.operations:
+    enabled: true
+    description: The number of operations on the InnoDB buffer pool.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [buffer_pool_operations]
+  mysql.buffer_pool.limit:
+    enabled: true
+    description: The configured size of the InnoDB buffer pool.
+    unit: By
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
+  mysql.buffer_pool.usage:
+    enabled: true
+    description: The number of bytes in the InnoDB buffer pool.
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [buffer_pool_data]
+  mysql.prepared_statements:
+    enabled: true
+    description: The number of times each type of prepared statement command has been issued.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [prepared_statements_command]
+  mysql.commands:
+    enabled: false
+    description: The number of times each type of command has been executed.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [command]
+  mysql.handlers:
+    enabled: true
+    description: The number of requests to various MySQL handlers.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [handler]
+  mysql.double_writes:
+    enabled: true
+    description: The number of writes to the InnoDB doublewrite buffer.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [double_writes]
+  mysql.log_operations:
+    enabled: true
+    description: The number of InnoDB log operations.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [log_operations]
+  mysql.operations:
+    enabled: true
+    description: The number of InnoDB operations.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [operations]
+  mysql.page_operations:
+    enabled: true
+    description: The number of InnoDB page operations.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [page_operations]
+  mysql.table.io.wait.count:
+    enabled: true
+    description: The total count of I/O wait events for a table.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [io_waits_operations, table_name, schema]
+  mysql.table.io.wait.time:
+    enabled: true
+    description: The total time of I/O wait events for a table.
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [io_waits_operations, table_name, schema]
+  mysql.index.io.wait.count:
+    enabled: true
+    description: The total count of I/O wait events for an index.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [io_waits_operations, table_name, schema, index_name]
+  mysql.index.io.wait.time:
+    enabled: true
+    description: The total time of I/O wait events for an index.
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [io_waits_operations, table_name, schema, index_name]
+  mysql.row_locks:
+    enabled: true
+    description: The number of InnoDB row locks.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [row_locks]
+  mysql.row_operations:
+    enabled: true
+    description: The number of InnoDB row operations.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [row_operations]
+  mysql.locks:
+    enabled: true
+    description: The number of MySQL locks.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [locks]
+  mysql.sorts:
+    enabled: true
+    description: The number of MySQL sorts.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [sorts]
+  mysql.threads:
+    enabled: true
+    description: The state of MySQL threads.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [threads]
+  mysql.client.network.io:
+    enabled: false
+    description: The number of transmitted bytes between server and clients.
+    unit: By
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [direction]
+  mysql.opened_resources:
+    enabled: true
+    description: The number of opened resources.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [opened_resources]
+  mysql.uptime:
+    enabled: true
+    description: The number of seconds that the server has been up.
+    unit: s
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  mysql.table.lock_wait.read.count:
+    enabled: false
+    description: The total table lock wait read events.
+    unit: "1"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [schema, table_name, read_lock_type]
+  mysql.table.lock_wait.read.time:
+    enabled: false
+    description: The total table lock wait read events times.
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [schema, table_name, read_lock_type]
+  mysql.table.lock_wait.write.count:
+    enabled: false
+    description: The total table lock wait write events.
+    unit: "1"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [schema, table_name, write_lock_type]
+  mysql.table.lock_wait.write.time:
+    enabled: false
+    description: The total table lock wait write events times.
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [schema, table_name, write_lock_type]
+  mysql.connection.count:
+    enabled: false
+    description: The number of connection attempts (successful or not) to the MySQL server.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  mysql.connection.errors:
+    enabled: false
+    description: Errors that occur during the client connection process.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [connection_error]
+  mysql.mysqlx_connections:
+    enabled: true
+    description: The number of mysqlx connections.
+    extended_documentation: This metric is specific for MySQL working as Document Store (X-Plugin). [more docs](https://dev.mysql.com/doc/refman/8.0/en/document-store.html)
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [connection_status]
+  mysql.joins:
+    enabled: false
+    description: The number of joins that perform table scans.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [join_kind]
+  mysql.tmp_resources:
+    enabled: true
+    description: The number of created temporary resources.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [tmp_resource]
+  mysql.replica.time_behind_source:
+    enabled: false
+    description: This field is an indication of how “late” the replica is.
+    unit: s
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: []
+  mysql.replica.sql_delay:
+    enabled: false
+    description: The number of seconds that the replica must lag the source.
+    unit: s
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: []
+  mysql.statement_event.count:
+    enabled: false
+    description: Summary of current and recent statement events.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [schema, digest, digest_text, event_state]
+  mysql.statement_event.wait.time:
+    enabled: false
+    description: The total wait time of the summarized timed events.
+    unit: ns
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [schema, digest, digest_text]
+  mysql.mysqlx_worker_threads:
+    enabled: false
+    description: The number of worker threads available.
+    unit: 1
+    extended_documentation: This metric is specific for MySQL working as Document Store (X-Plugin). [more docs](https://dev.mysql.com/doc/refman/8.0/en/document-store.html)
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [mysqlx_threads]
+  mysql.table_open_cache:
+    enabled: false
+    description: The number of hits, misses or overflows for open tables cache lookups.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [cache_status]
+  mysql.query.client.count:
+    enabled: false
+    description: The number of statements executed by the server. This includes only statements sent to the server by clients.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  mysql.query.count:
+    enabled: false
+    description: The number of statements executed by the server.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
+  mysql.query.slow.count:
+    enabled: false
+    description: The number of slow queries.
+    unit: 1
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/nginxreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/nginxreceiver_metadata.yaml
@@ -1,0 +1,57 @@
+type: nginx
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski]
+
+attributes:
+  state:
+    description: The state of a connection
+    type: string
+    enum:
+    - active
+    - reading
+    - writing
+    - waiting
+
+metrics:
+  nginx.requests:
+    enabled: true
+    description: Total number of requests made to the server since it started
+    unit: requests
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  nginx.connections_accepted:
+    enabled: true
+    description: The total number of accepted client connections
+    unit: connections
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  nginx.connections_handled:
+    enabled: true
+    description: The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).
+    unit: connections
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: []
+  nginx.connections_current:
+    enabled: true
+    description: The current number of nginx connections by state
+    unit: connections
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [state]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/nsxtreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/nsxtreceiver_metadata.yaml
@@ -1,0 +1,114 @@
+type: nsxt
+
+status:
+  class: receiver
+  stability:
+    alpha: [metrics]
+  distributions: [contrib, sumo]
+  codeowners:
+    active: [dashpole, schmikei]
+
+resource_attributes:
+  nsxt.node.name:
+    description: The name of the NSX Node.
+    enabled: true
+    type: string
+  nsxt.node.id:
+    description: The ID of the NSX Node.
+    enabled: true
+    type: string
+  nsxt.node.type:
+    description: The type of NSX Node.
+    enabled: true
+    type: string
+  device.id:
+    description: The name of the network interface.
+    enabled: true
+    type: string
+
+attributes:
+  direction:
+    description: The direction of network flow.
+    type: string
+    enum:
+      - received
+      - transmitted
+  disk_state:
+    name_override: state
+    description: The state of storage space.
+    type: string
+    enum:
+      - used
+      - available
+  packet.type:
+    name_override: type
+    description: The type of packet counter.
+    type: string
+    enum:
+      - dropped
+      - errored
+      - success
+  class:
+    description: The CPU usage of the architecture allocated for either DPDK (datapath) or non-DPDK (services) processes.
+    type: string
+    enum:
+      - datapath
+      - services
+
+metrics:
+  nsxt.node.network.io:
+    description: The number of bytes which have flowed through the network interface.
+    unit: "By"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+    attributes: [direction]
+  nsxt.node.network.packet.count:
+    description: The number of packets which have flowed through the network interface on the node.
+    unit: "{packets}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+    attributes: [direction, packet.type]
+  nsxt.node.cpu.utilization:
+    description: The average amount of CPU being used by the node.
+    unit: "%"
+    gauge:
+      value_type: double
+    enabled: true
+    attributes: [class]
+  nsxt.node.filesystem.utilization:
+    description: The percentage of storage space utilized.
+    unit: "%"
+    gauge:
+      value_type: double
+    enabled: true
+  nsxt.node.filesystem.usage:
+    description: The amount of storage space used by the node.
+    unit: By
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    enabled: true
+    attributes: [disk_state]
+  nsxt.node.memory.usage:
+    description: The memory usage of the node.
+    unit: KBy
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    enabled: true
+  nsxt.node.memory.cache.usage:
+    description: The size of the node's memory cache.
+    unit: KBy
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    enabled: true

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/oracledbreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/oracledbreceiver_metadata.yaml
@@ -1,0 +1,254 @@
+type: oracledb
+
+status:
+  class: receiver
+  stability:
+    alpha: [metrics]
+  distributions: [contrib, splunk]
+  codeowners:
+    active: [dmitryax, crobert-1, atoulme]
+
+resource_attributes:
+  oracledb.instance.name:
+    description: The name of the instance that data is coming from.
+    enabled: true
+    type: string
+
+attributes:
+  session_status:
+    description: Session status
+    type: string
+  session_type:
+    description: Session type
+    type: string
+  tablespace_name:
+    description: Tablespace name
+    type: string
+
+metrics:
+  oracledb.cpu_time:
+    description: Cumulative CPU time, in seconds
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: double
+    unit: s
+  oracledb.enqueue_deadlocks:
+    description: Total number of deadlocks between table or row locks in different
+      sessions.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{deadlocks}"
+  oracledb.exchange_deadlocks:
+    description: Number of times that a process detected a potential deadlock when
+      exchanging two buffers and raised an internal, restartable error. Index scans
+      are the only operations that perform exchanges.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{deadlocks}"
+  oracledb.executions:
+    description: Total number of calls (user and recursive) that executed SQL statements
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{executions}"
+  oracledb.logical_reads:
+    description: Number of logical reads
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{reads}"
+  oracledb.hard_parses:
+    description: Number of hard parses
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{parses}"
+  oracledb.parse_calls:
+    description: Total number of parse calls.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{parses}"
+  oracledb.pga_memory:
+    description: Session PGA (Program Global Area) memory
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: By
+  oracledb.physical_reads:
+    description: Number of physical reads
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{reads}"
+  oracledb.user_commits:
+    description: Number of user commits. When a user commits a transaction, the redo
+      generated that reflects the changes made to database blocks must be written
+      to disk. Commits often represent the closest thing to a user transaction rate.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{commits}"
+  oracledb.user_rollbacks:
+    description: Number of times users manually issue the ROLLBACK statement or an
+      error occurs during a user's transactions
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: 1
+  oracledb.sessions.usage:
+    attributes:
+      - session_type
+      - session_status
+    description: Count of active sessions.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{sessions}"
+  oracledb.processes.usage:
+    description: Current count of active processes.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{processes}"
+  oracledb.processes.limit:
+    description: Maximum limit of active processes, -1 if unlimited.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{processes}"
+  oracledb.sessions.limit:
+    description: Maximum limit of active sessions, -1 if unlimited.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{sessions}"
+  oracledb.enqueue_locks.usage:
+    description: Current count of active enqueue locks.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{locks}"
+  oracledb.enqueue_locks.limit:
+    description: Maximum limit of active enqueue locks, -1 if unlimited.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{locks}"
+  oracledb.dml_locks.usage:
+    description: Current count of active DML (Data Manipulation Language) locks.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{locks}"
+  oracledb.dml_locks.limit:
+    description: Maximum limit of active DML (Data Manipulation Language) locks, -1 if unlimited.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{locks}"
+  oracledb.enqueue_resources.usage:
+    description: Current count of active enqueue resources.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{resources}"
+  oracledb.enqueue_resources.limit:
+    description: Maximum limit of active enqueue resources, -1 if unlimited.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{resources}"
+  oracledb.transactions.usage:
+    description: Current count of active transactions.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{transactions}"
+  oracledb.transactions.limit:
+    description: Maximum limit of active transactions, -1 if unlimited.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: "{transactions}"
+  oracledb.tablespace_size.limit:
+    attributes:
+      - tablespace_name
+    description: Maximum size of tablespace in bytes, -1 if unlimited.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: By
+  oracledb.tablespace_size.usage:
+    attributes:
+      - tablespace_name
+    description: Used tablespace in bytes.
+    enabled: true
+    gauge:
+      value_type: int
+      input_type: string
+    unit: By
+  oracledb.db_block_gets:
+    description: Number of times a current block was requested from the buffer cache.
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{gets}"
+  oracledb.consistent_gets:
+    description: Number of times a consistent read was requested for a block from the buffer cache.
+    enabled: false
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{gets}"

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/postgresqlreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/postgresqlreceiver_metadata.yaml
@@ -1,0 +1,309 @@
+type: postgresql
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, splunk, observiq, sumo]
+  codeowners:
+    active: [djaglowski]
+
+resource_attributes:
+  postgresql.database.name:
+    description: The name of the database.
+    enabled: true
+    type: string
+  postgresql.table.name:
+    description: The schema name followed by the table name.
+    enabled: true
+    type: string
+  postgresql.index.name:
+    description: The name of the index on a table.
+    enabled: true
+    type: string
+
+attributes:
+  bg_buffer_source:
+    description: The source of a buffer write.
+    type: string
+    enum:
+      - backend
+      - backend_fsync
+      - checkpoints
+      - bgwriter
+    name_override: source
+  bg_checkpoint_type:
+    description: The type of checkpoint state.
+    type: string
+    enum:
+      - requested
+      - scheduled
+    name_override: type
+  bg_duration_type:
+    description: The type of time spent during the checkpoint.
+    type: string
+    enum:
+      - sync
+      - write
+    name_override: type
+  lock_type:
+    description: Type of the lockable object.
+    type: string
+  mode:
+    description: Name of the lock mode held or desired by the process.
+    type: string
+  source:
+    description: The block read source type.
+    type: string
+    enum:
+      - heap_read
+      - heap_hit
+      - idx_read
+      - idx_hit
+      - toast_read
+      - toast_hit
+      - tidx_read
+      - tidx_hit
+  operation:
+    description: The database operation.
+    type: string
+    enum: [ins, upd, del, hot_upd]
+  relation:
+    description: OID of the relation targeted by the lock, or null if the target is not a relation or part of a relation.
+    type: string
+  replication_client:
+    description: The IP address of the client connected to this backend. If this field is "unix", it indicates either that the client is connected via a Unix socket.
+    type: string
+  state:
+    description: The tuple (row) state.
+    type: string
+    enum: [dead, live]
+  wal_operation_lag:
+    name_override: operation
+    description: The operation which is responsible for the lag.
+    type: string
+    enum: [flush, replay, write]
+
+metrics:
+  postgresql.bgwriter.buffers.allocated:
+    description: Number of buffers allocated.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{buffers}"
+  postgresql.bgwriter.buffers.writes:
+    attributes:
+      - bg_buffer_source
+    description: Number of buffers written.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{buffers}"
+  postgresql.bgwriter.checkpoint.count:
+    attributes:
+      - bg_checkpoint_type
+    description: The number of checkpoints performed.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{checkpoints}"
+  postgresql.bgwriter.duration:
+    attributes:
+      - bg_duration_type
+    description: Total time spent writing and syncing files to disk by checkpoints.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: double
+    unit: ms
+  postgresql.bgwriter.maxwritten:
+    description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: 1
+  postgresql.blocks_read:
+    enabled: true
+    description: The number of blocks read.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [source]
+  postgresql.commits:
+    enabled: true
+    description: The number of commits.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  postgresql.database.count:
+    description: Number of user databases.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{databases}"
+  postgresql.database.locks:
+    enabled: false
+    description: The number of database locks.
+    unit: "{lock}"
+    gauge:
+      value_type: int
+    attributes: [relation, mode, lock_type]
+  postgresql.db_size:
+    enabled: true
+    description: The database disk usage.
+    unit: By
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+  postgresql.backends:
+    enabled: true
+    description: The number of backends.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+  postgresql.connection.max:
+    enabled: true
+    description: Configured maximum number of client connections allowed
+    unit: "{connections}"
+    gauge:
+      value_type: int
+  postgresql.rows:
+    enabled: true
+    description: The number of rows in the database.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [state]
+  postgresql.index.scans:
+    description: The number of index scans on a table.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+    unit: "{scans}"
+  postgresql.index.size:
+    description: The size of the index on disk.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: "By"
+  postgresql.operations:
+    enabled: true
+    description: The number of db row operations.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [operation]
+  postgresql.replication.data_delay:
+    attributes: [replication_client]
+    description: The amount of data delayed in replication.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: By
+  postgresql.rollbacks:
+    enabled: true
+    description: The number of rollbacks.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  postgresql.deadlocks:
+    enabled: false
+    description: The number of deadlocks.
+    unit: "{deadlock}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  postgresql.sequential_scans:
+    enabled: false
+    description: The number of sequential scans.
+    unit: "{sequential_scan}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  postgresql.table.count:
+    description: Number of user tables in a database.
+    enabled: true
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+    unit: "{table}"
+  postgresql.table.size:
+    description: Disk space used by a table.
+    enabled: true
+    unit: By
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+  postgresql.table.vacuum.count:
+    description: Number of times a table has manually been vacuumed.
+    enabled: true
+    unit: "{vacuums}"
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+  postgresql.temp_files:
+    enabled: false
+    description: The number of temp files.
+    unit: "{temp_file}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative   
+  postgresql.wal.age:
+    description: Age of the oldest WAL file.
+    extended_documentation: |
+     This metric requires WAL to be enabled with at least one replica.
+    enabled: true
+    unit: s
+    gauge:
+      value_type: int
+  postgresql.wal.lag:
+    attributes: [wal_operation_lag, replication_client]
+    description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
+    enabled: true
+    unit: s
+    gauge:
+      value_type: int
+    extended_documentation: |
+      This metric requires WAL to be enabled with at least one replica.
+  postgresql.wal.delay:
+    attributes: [wal_operation_lag, replication_client]
+    description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
+    enabled: false
+    unit: s
+    gauge:
+      value_type: double
+    extended_documentation: |
+      This metric requires WAL to be enabled with at least one replica.
+  

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/rabbitmqreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/rabbitmqreceiver_metadata.yaml
@@ -1,0 +1,82 @@
+type: rabbitmq
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski, cpheps]
+
+resource_attributes:
+  rabbitmq.queue.name:
+    description: The name of the RabbitMQ queue.
+    enabled: true
+    type: string
+  rabbitmq.node.name:
+    description: The name of the RabbitMQ node.
+    enabled: true
+    type: string
+  rabbitmq.vhost.name:
+    description: The name of the RabbitMQ vHost.
+    enabled: true
+    type: string
+
+attributes:
+  message.state:
+    name_override: state
+    description: The state of messages in a queue.
+    type: string
+    enum:
+      - ready
+      - unacknowledged
+metrics:
+  rabbitmq.consumer.count:
+    description: The number of consumers currently reading from the queue.
+    unit: "{consumers}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  rabbitmq.message.delivered:
+    description: The number of messages delivered to consumers.
+    unit: "{messages}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  rabbitmq.message.published:
+    description: The number of messages published to a queue.
+    unit: "{messages}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  rabbitmq.message.acknowledged:
+    description: The number of messages acknowledged by consumers.
+    unit: "{messages}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  rabbitmq.message.dropped:
+    description: The number of messages dropped as unroutable.
+    unit: "{messages}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  rabbitmq.message.current:
+    description: The total number of messages currently in the queue.
+    unit: "{messages}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [message.state]
+    enabled: true

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/redisreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/redisreceiver_metadata.yaml
@@ -1,0 +1,346 @@
+type: redis
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, splunk, observiq, sumo]
+  codeowners:
+    active: [dmitryax, hughesjj]
+
+resource_attributes:
+  redis.version:
+    description: Redis server's version.
+    enabled: true
+    type: string
+  server.address:
+    description: Redis server's address
+    enabled: false
+    type: string
+  server.port:
+    description: Redis server's port
+    enabled: false
+    type: string
+
+attributes:
+  state:
+    description: Redis CPU usage state
+    type: string
+    # Redis versions < 6.0 have:
+    #   used_cpu_sys: System CPU consumed by the Redis server, which is the sum of system CPU consumed by all threads of the server process (main thread and background threads)
+    #   used_cpu_user: User CPU consumed by the Redis server, which is the sum of user CPU consumed by all threads of the server process (main thread and background threads)
+    #   used_cpu_sys_children: System CPU consumed by the background processes
+    #   used_cpu_user_children: User CPU consumed by the background processes
+    # Redis versions >= 6.0 have two more:
+    #   used_cpu_sys_main_thread: System CPU consumed by the Redis server main thread
+    #   used_cpu_user_main_thread: User CPU consumed by the Redis server main thread
+    enum:
+      - sys
+      - sys_children
+      - sys_main_thread
+      - user
+      - user_children
+      - user_main_thread
+  db:
+    description: Redis database identifier
+    type: string
+  role:
+    description: Redis node's role
+    type: string
+    enum:
+      - replica
+      - primary
+  cmd:
+    description: Redis command name
+    type: string
+  percentile:
+    description: Percentile
+    type: string
+    enum:
+      - p50
+      - p99
+      - p99.9
+
+metrics:
+  redis.maxmemory:
+    enabled: false
+    description: The value of the maxmemory configuration directive
+    unit: By
+    gauge:
+      value_type: int
+
+  redis.role:
+    enabled: false
+    description: Redis node's role
+    unit: "{role}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+    attributes: [role]
+
+  redis.cmd.calls:
+    enabled: false
+    description: Total number of calls for a command
+    unit: "{call}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [cmd]
+
+  redis.cmd.usec:
+    enabled: false
+    description: Total time for all executions of this command
+    unit: us
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [cmd]
+
+  redis.cmd.latency:
+    enabled: false
+    description: Command execution latency
+    unit: s
+    gauge:
+      value_type: double
+    attributes: [cmd, percentile]
+
+  redis.uptime:
+    enabled: true
+    description: Number of seconds since Redis server start
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  redis.cpu.time:
+    enabled: true
+    description: System CPU consumed by the Redis server in seconds since server start
+    unit: s
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [state]
+
+  redis.clients.connected:
+    enabled: true
+    description: Number of client connections (excluding connections from replicas)
+    unit: "{client}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  redis.clients.max_input_buffer:
+    enabled: true
+    description: Biggest input buffer among current client connections
+    unit: "By"
+    gauge:
+      value_type: int
+
+  redis.clients.max_output_buffer:
+    enabled: true
+    description: Longest output list among current client connections
+    unit: "By"
+    gauge:
+      value_type: int
+
+  redis.clients.blocked:
+    enabled: true
+    description: Number of clients pending on a blocking call
+    unit: "{client}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  redis.keys.expired:
+    enabled: true
+    description: Total number of key expiration events
+    unit: "{event}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+
+  redis.keys.evicted:
+    enabled: true
+    description: Number of evicted keys due to maxmemory limit
+    unit: "{key}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  redis.connections.received:
+    enabled: true
+    description: Total number of connections accepted by the server
+    unit: "{connection}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  redis.connections.rejected:
+    enabled: true
+    description: Number of connections rejected because of maxclients limit
+    unit: "{connection}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  redis.memory.used:
+    enabled: true
+    description: Total number of bytes allocated by Redis using its allocator
+    unit: By
+    gauge:
+     value_type: int
+
+  redis.memory.peak:
+    enabled: true
+    description: Peak memory consumed by Redis (in bytes)
+    unit: By
+    gauge:
+      value_type: int
+
+  redis.memory.rss:
+    enabled: true
+    description: Number of bytes that Redis allocated as seen by the operating system
+    unit: By
+    gauge:
+      value_type: int
+
+  redis.memory.lua:
+    enabled: true
+    description: Number of bytes used by the Lua engine
+    unit: By
+    gauge:
+      value_type: int
+
+  redis.memory.fragmentation_ratio:
+    enabled: true
+    description: Ratio between used_memory_rss and used_memory
+    unit: 1
+    gauge:
+      value_type: double
+
+  redis.rdb.changes_since_last_save:
+    enabled: true
+    description: Number of changes since the last dump
+    unit: "{change}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  redis.commands:
+    enabled: true
+    description: Number of commands processed per second
+    unit: "{ops}/s"
+    gauge:
+      value_type: int
+
+  redis.commands.processed:
+    enabled: true
+    description: Total number of commands processed by the server
+    unit: "{command}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  redis.net.input:
+    enabled: true
+    description: The total number of bytes read from the network
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  redis.net.output:
+    enabled: true
+    description: The total number of bytes written to the network
+    unit: By
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  redis.keyspace.hits:
+    enabled: true
+    description: Number of successful lookup of keys in the main dictionary
+    unit: "{hit}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  redis.keyspace.misses:
+    enabled: true
+    description: Number of failed lookup of keys in the main dictionary
+    unit: "{miss}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+
+  redis.latest_fork:
+    enabled: true
+    description: Duration of the latest fork operation in microseconds
+    unit: us
+    gauge:
+      value_type: int
+
+  redis.slaves.connected:
+    enabled: true
+    description: Number of connected replicas
+    unit: "{replica}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+
+  redis.replication.backlog_first_byte_offset:
+    enabled: true
+    description: The master offset of the replication backlog buffer
+    unit: "By"
+    gauge:
+      value_type: int
+
+  redis.replication.offset:
+    enabled: true
+    description: The server's current replication offset
+    unit: "By"
+    gauge:
+      value_type: int
+
+  redis.db.keys:
+    enabled: true
+    description: "Number of keyspace keys"
+    unit: "{key}"
+    gauge:
+      value_type: int
+    attributes: [db]
+
+  redis.db.expires:
+    enabled: true
+    description: "Number of keyspace keys with an expiration"
+    unit: "{key}"
+    gauge:
+      value_type: int
+    attributes: [db]
+
+  redis.db.avg_ttl:
+    enabled: true
+    description: "Average keyspace keys TTL"
+    unit: ms
+    gauge:
+      value_type: int
+    attributes: [db]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/riakreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/riakreceiver_metadata.yaml
@@ -1,0 +1,82 @@
+type: riak
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski, armstrmi]
+
+resource_attributes:
+  riak.node.name:
+    description: The name this node uses to identify itself.
+    enabled: true
+    type: string
+
+attributes:
+  request:
+    description: The request operation type.
+    type: string
+    enum:
+      - put
+      - get
+  operation:
+    description: The operation type for index operations.
+    type: string
+    enum:
+      - read
+      - write
+      - delete
+
+metrics:
+  riak.node.operation.count:
+    description: The number of operations performed by the node.
+    unit: "{operation}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+    attributes: [request]
+  riak.node.operation.time.mean:
+    description: The mean time between request and response for operations performed by the node over the last minute.
+    unit: us
+    gauge:
+      value_type: int
+    enabled: true
+    attributes: [request]
+  riak.node.read_repair.count:
+    description: The number of read repairs performed by the node.
+    unit: "{read_repair}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  riak.memory.limit:
+    description: The amount of memory allocated to the node.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+  riak.vnode.operation.count:
+    description: The number of operations performed by vnodes on the node.
+    unit: "{operation}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+    enabled: true
+    attributes: [request]
+  riak.vnode.index.operation.count:
+    description: The number of index operations performed by vnodes on the node.
+    unit: "{operation}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+    attributes: [operation]
+    enabled: true

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/saphanareceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/saphanareceiver_metadata.yaml
@@ -1,0 +1,646 @@
+type: saphana
+
+status:
+  class: receiver
+  stability:
+    development: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [dehaansa]
+
+resource_attributes:
+  saphana.host:
+    type: string
+    description: The SAP HANA host.
+    enabled: true
+  db.system:
+    type: string
+    description: The type of database system.
+    enabled: true
+
+attributes:
+  database:
+    description: The SAP HANA database.
+    type: string
+  system:
+    description: The SAP HANA system.
+    type: string
+  product:
+    description: The SAP HANA product.
+    type: string
+  primary_host:
+    name_override: primary
+    description: The primary SAP HANA host in replication.
+    type: string
+  secondary_host:
+    name_override: secondary
+    description: The secondary SAP HANA host in replication.
+    type: string
+  port:
+    description: The SAP HANA port.
+    type: string
+  replication_mode:
+    name_override: mode
+    description: The replication mode.
+    type: string
+  component:
+    description: The SAP HANA component.
+    type: string
+  schema:
+    description: The SAP HANA schema.
+    type: string
+  service:
+    description: The SAP HANA service.
+    type: string
+  path:
+    description: The SAP HANA disk path.
+    type: string
+  disk_usage_type:
+    name_override: usage_type
+    description: The SAP HANA disk & volume usage type.
+    type: string
+  transaction_type:
+    name_override: type
+    description: The transaction type.
+    type: string
+    enum:
+    - update
+    - commit
+    - rollback
+  connection_status:
+    name_override: status
+    description: The connection status.
+    type: string
+    enum:
+    - running
+    - idle
+    - queueing
+  cpu_type:
+    name_override: type
+    description: The type of cpu.
+    type: string
+    enum:
+    - user
+    - system
+    - io_wait
+    - idle
+  alert_rating:
+    name_override: rating
+    description: The alert rating.
+    type: string
+  column_memory_type:
+    name_override: type
+    description: The type of column store memory.
+    type: string
+    enum:
+    - main
+    - delta
+  column_memory_subtype:
+    name_override: subtype
+    description: The subtype of column store memory.
+    type: string
+    enum:
+    - data
+    - dict
+    - index
+    - misc
+  row_memory_type:
+    name_override: type
+    description: The type of row store memory.
+    type: string
+    enum:
+    - fixed
+    - variable
+  schema_memory_type:
+    name_override: type
+    description: The type of schema memory.
+    type: string
+    enum:
+    - main
+    - delta
+    - history_main
+    - history_delta
+  schema_record_type:
+    name_override: type
+    description: The type of schema record.
+    type: string
+    enum:
+    - main
+    - delta
+    - history_main
+    - history_delta
+  memory_state_used_free:
+    name_override: state
+    description: The state of memory.
+    type: string
+    enum:
+    - used
+    - free
+  disk_state_used_free:
+    name_override: state
+    description: The state of the disk storage.
+    type: string
+    enum:
+    - used
+    - free
+  host_swap_state:
+    name_override: state
+    description: The state of swap data.
+    type: string
+    enum:
+    - used
+    - free
+  schema_operation_type:
+    name_override: type
+    description: The type of operation.
+    type: string
+    enum:
+    - read
+    - write
+    - merge
+  service_status:
+    name_override: status
+    description: The status of services.
+    type: string
+    enum:
+    - active
+    - inactive
+  thread_status:
+    name_override: status
+    description: The status of threads.
+    type: string
+    enum:
+    - active
+    - inactive
+  service_memory_used_type:
+    name_override: type
+    description: The type of service memory.
+    type: string
+    enum:
+    - logical
+    - physical
+  volume_operation_type:
+    name_override: type
+    description: The type of operation.
+    type: string
+    enum:
+    - read
+    - write
+  active_pending_request_state:
+    name_override: state
+    description: The state of network request.
+    type: string
+    enum:
+    - active
+    - pending
+  internal_external_request_type:
+    name_override: type
+    description: The type of network request.
+    type: string
+    enum:
+    - internal
+    - external
+
+metrics:
+  saphana.connection.count:
+    description: The number of current connections.
+    unit: '{connections}'
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [connection_status]
+    enabled: true
+  saphana.cpu.used:
+    description: Total CPU time spent.
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [cpu_type]
+    enabled: true
+  saphana.alert.count:
+    description: Number of current alerts.
+    unit: '{alerts}'
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [alert_rating]
+    enabled: true
+  saphana.uptime:
+    description: The uptime of the database.
+    unit: s
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [system, database]
+    enabled: true
+  saphana.replication.backlog.time:
+    description: The current replication backlog.
+    unit: us
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [primary_host, secondary_host, port, replication_mode]
+    enabled: true
+  saphana.replication.backlog.size:
+    description: The current replication backlog size.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [primary_host, secondary_host, port, replication_mode]
+    enabled: true
+  saphana.replication.average_time:
+    description: The average amount of time consumed replicating a log.
+    unit: us
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: [primary_host, secondary_host, port, replication_mode]
+    enabled: true
+  saphana.backup.latest:
+    description: The age of the latest backup by start time.
+    unit: s
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    enabled: true
+  saphana.transaction.count:
+    description: The number of transactions.
+    unit: '{transactions}'
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [transaction_type]
+    enabled: true
+  saphana.transaction.blocked:
+    description: The number of transactions waiting for a lock.
+    unit: '{transactions}'
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+    enabled: true
+  saphana.license.expiration.time:
+    description: The amount of time remaining before license expiration.
+    unit: s
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [system, product]
+    enabled: true
+  saphana.license.limit:
+    description: The allowed product usage as specified by the license (for example, main memory).
+    unit: '{licenses}'
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [system, product]
+    enabled: true
+  saphana.license.peak:
+    description: The peak product usage value during last 13 months, measured periodically.
+    unit: '{licenses}'
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [system, product]
+    enabled: true
+  saphana.instance.memory.current:
+    description: The size of the memory pool for all SAP HANA processes.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [memory_state_used_free]
+    enabled: true
+  saphana.instance.memory.used.peak:
+    description: The peak memory from the memory pool used by SAP HANA processes since the instance started (this is a sample-based value).
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+    enabled: true
+  saphana.instance.code_size:
+    description: The instance code size, including shared libraries of SAP HANA processes.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+    enabled: true
+  saphana.instance.memory.shared.allocated:
+    description: The shared memory size of SAP HANA processes.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: []
+    enabled: true
+  saphana.host.memory.current:
+    description: The amount of physical memory on the host.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [memory_state_used_free]
+    enabled: true
+  saphana.host.swap.current:
+    description: The amount of swap space on the host.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [host_swap_state]
+    enabled: true
+  saphana.column.memory.used:
+    description: The memory used in all columns.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [column_memory_type, column_memory_subtype]
+    enabled: true
+  saphana.row_store.memory.used:
+    description: The used memory for all row tables.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [row_memory_type]
+    enabled: true
+  saphana.component.memory.used:
+    description: The memory used in components.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [component]
+    enabled: true
+  saphana.schema.memory.used.current:
+    description: The memory size for all tables in schema.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [schema, schema_memory_type]
+    enabled: true
+  saphana.schema.memory.used.max:
+    description: The estimated maximum memory consumption for all fully loaded tables in schema (data for open transactions is not included).
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [schema]
+    enabled: true
+  saphana.schema.record.count:
+    description: The number of records for all tables in schema.
+    unit: '{records}'
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [schema, schema_record_type]
+    enabled: true
+  saphana.schema.record.compressed.count:
+    description: The number of entries in main during the last optimize compression run for all tables in schema.
+    unit: '{records}'
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [schema]
+    enabled: true
+  saphana.schema.operation.count:
+    description: The number of operations done on all tables in schema.
+    unit: '{operations}'
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [schema, schema_operation_type]
+    enabled: true
+  saphana.service.count:
+    description: The number of services in a given status.
+    unit: '{services}'
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [service_status]
+    enabled: true
+  saphana.service.thread.count:
+    description: The number of service threads in a given status.
+    unit: '{threads}'
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [thread_status]
+    enabled: true
+  saphana.service.memory.used:
+    description: The used memory from the operating system perspective.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [service, service_memory_used_type]
+    enabled: true
+  saphana.service.code_size:
+    description: The service code size, including shared libraries.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [service]
+    enabled: true
+  saphana.service.stack_size:
+    description: The service stack size.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [service]
+    enabled: true
+  saphana.service.memory.heap.current:
+    description: The size of the heap portion of the memory pool.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [service, memory_state_used_free]
+    enabled: true
+  saphana.service.memory.shared.current:
+    description: The size of the shared portion of the memory pool.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [service, memory_state_used_free]
+    enabled: true
+  saphana.service.memory.compactors.allocated:
+    description: The part of the memory pool that can potentially (if unpinned) be freed during a memory shortage.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [service]
+    enabled: true
+  saphana.service.memory.compactors.freeable:
+    description: The memory that can be freed during a memory shortage.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [service]
+    enabled: true
+  saphana.service.memory.limit:
+    description: The configured maximum memory pool size.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [service]
+    enabled: true
+  saphana.service.memory.effective_limit:
+    description: The effective maximum memory pool size, calculated considering the pool sizes of other processes.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [service]
+    enabled: true
+  saphana.disk.size.current:
+    description: The disk size.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [path, disk_usage_type, disk_state_used_free]
+    enabled: true
+  saphana.volume.operation.count:
+    description: The number of operations executed.
+    unit: '{operations}'
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [path, disk_usage_type, volume_operation_type]
+    enabled: true
+  saphana.volume.operation.size:
+    description: The size of operations executed.
+    unit: By
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [path, disk_usage_type, volume_operation_type]
+    enabled: true
+  saphana.volume.operation.time:
+    description: The time spent executing operations.
+    unit: ms
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [path, disk_usage_type, volume_operation_type]
+    enabled: true
+  saphana.network.request.count:
+    description: The number of active and pending service requests.
+    unit: '{requests}'
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [active_pending_request_state]
+    enabled: true
+  saphana.network.request.finished.count:
+    description: The number of service requests that have completed.
+    unit: '{requests}'
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+      input_type: string
+    attributes: [internal_external_request_type]
+    enabled: true
+  saphana.network.request.average_time:
+    description: The average response time calculated over recent requests
+    unit: ms
+    gauge:
+      value_type: double
+      input_type: string
+    attributes: []
+    enabled: true

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/snowflakereceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/snowflakereceiver_metadata.yaml
@@ -1,0 +1,315 @@
+type: snowflake
+
+status:
+  class: receiver
+  stability:
+    alpha: [metrics]
+  distributions: [contrib]
+  codeowners:
+    active: [dmitryax, shalper2]
+
+# every meter will have these attributes
+resource_attributes:
+  snowflake.account.name:
+    description: Snowflake account being used by receiver.
+    enabled: true
+    type: string
+
+attributes:
+  service_type:
+    description: Service type associateed with metric query
+    type: string
+  error_message:
+    description: Error message reported by query if present
+    type: string 
+  reported_client_type:
+    description: Client type used for attempt
+    type: string
+  is_success:
+    description: Login status (success or failure).
+    type: string
+  schema_name:
+    description: Name of schema associated with query result. 
+    type: string
+  execution_status:
+    description: Execution status of query being reported.
+    type: string
+  query_type:
+    description: Type of query performed.
+    type: string
+  database_name:
+    description: Name of database being queried (default is snowflake).
+    type: string
+  warehouse_size:
+    description: Size of warehouse being reported on.
+    type: string
+  pipe_name:
+    description: Name of snowpipe. 
+    type: string
+  warehouse_name:
+    description: Name of warehouse in query being reported on.
+    type: string
+  user_name:
+    description: Username in query being reported.
+    type: string
+
+
+# sql query associated with each group of metrics included
+metrics:
+  # Billing Metrics
+  snowflake.billing.cloud_service.total:
+    description: Reported total credits used in the cloud service over the last 24 hour window.
+    unit: "{credits}"
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [service_type]
+  snowflake.billing.total_credit.total:
+    description: Reported total credits used across account over the last 24 hour window.
+    unit: "{credits}"
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [service_type]
+  snowflake.billing.virtual_warehouse.total:
+    description: Reported total credits used by virtual warehouse service over the last 24 hour window.
+    unit: "{credits}"
+    attributes: [service_type]
+    gauge:
+      value_type: double
+    enabled: false
+
+  # Warehouse Billing Metrics
+  snowflake.billing.warehouse.cloud_service.total:
+    description: Credits used across cloud service for given warehouse over the last 24 hour window.
+    unit: "{credits}"
+    gauge: 
+      value_type: double
+    enabled: false
+    attributes: [warehouse_name]
+  snowflake.billing.warehouse.total_credit.total:
+    description: Total credits used associated with given warehouse over the last 24 hour window.
+    unit: "{credits}"
+    gauge: 
+      value_type: double
+    enabled: false
+    attributes: [warehouse_name]
+  snowflake.billing.warehouse.virtual_warehouse.total:
+    description: Total credits used by virtual warehouse service for given warehouse over the last 24 hour window.
+    unit: "{credits}"
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [warehouse_name]
+
+  # Login (Security) metrics 
+  snowflake.logins.total:
+    description: Total login attempts for account over the last 24 hour window.
+    unit: 1
+    gauge:
+      value_type: int 
+    enabled: false 
+    attributes: [error_message, reported_client_type, is_success]
+
+  # High level low dimensionality query metrics 
+  snowflake.query.blocked:
+    description: Blocked query count for warehouse over the last 24 hour window.
+    unit: 1
+    gauge:
+      value_type: double
+    enabled: true 
+    attributes: [warehouse_name]
+  snowflake.query.executed:
+    description: Executed query count for warehouse over the last 24 hour window.
+    unit: 1
+    gauge:
+      value_type: double
+    enabled: true 
+    attributes: [warehouse_name]
+  snowflake.query.queued_overload:
+    description: Overloaded query count for warehouse over the last 24 hour window.
+    unit: 1
+    gauge:
+      value_type: double
+    enabled: true 
+    attributes: [warehouse_name]
+  snowflake.query.queued_provision:
+    description: Number of compute resources queued for provisioning over the last 24 hour window.
+    unit: 1
+    gauge:
+      value_type: double 
+    enabled: true 
+    attributes: [warehouse_name]
+
+  # DB metrics
+  snowflake.database.query.count:
+    description: Total query count for database over the last 24 hour window.
+    unit: 1
+    gauge:
+      value_type: int 
+    enabled: true
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.database.bytes_scanned.avg:
+    description: Average bytes scanned in a database over the last 24 hour window.
+    unit: By
+    gauge:
+      value_type: double
+    enabled: true
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.query.bytes_deleted.avg:
+    description: Average bytes deleted in database over the last 24 hour window.
+    unit: By
+    gauge:
+      value_type: double 
+    enabled: true
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.query.bytes_spilled.local.avg:
+    description: Avergae bytes spilled (intermediate results do not fit in memory) by local storage over the last 24 hour window.
+    unit: By 
+    gauge:
+      value_type: double
+    enabled: false 
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.query.bytes_spilled.remote.avg:
+    description: Avergae bytes spilled (intermediate results do not fit in memory) by remote storage over the last 24 hour window.
+    unit: By
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.query.bytes_written.avg:
+    description: Average bytes written by database over the last 24 hour window.
+    unit: By 
+    gauge: 
+      value_type: double
+    enabled: true
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.query.compilation_time.avg:
+    description: Average time taken to compile query over the last 24 hour window.
+    unit: s
+    gauge:
+      value_type: double
+    enabled: true
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.query.data_scanned_cache.avg:
+    description: Average percentage of data scanned from cache over the last 24 hour window.
+    unit: 1
+    gauge:
+      value_type: double
+    enabled: false 
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.query.execution_time.avg:
+    description: Average time spent executing queries in database over the last 24 hour window.
+    unit: s 
+    gauge: 
+      value_type: double
+    enabled: true
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.query.partitions_scanned.avg:
+    description: Number of partitions scanned during query so far over the last 24 hour window. 
+    unit: 1
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.queued_overload_time.avg:
+    description: Average time spent in warehouse queue due to warehouse being overloaded over the last 24 hour window.
+    unit: s 
+    gauge: 
+      value_type: double
+    enabled: true 
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.queued_provisioning_time.avg:
+    description: Average time spent in warehouse queue waiting for resources to provision over the last 24 hour window.
+    unit: s 
+    gauge:
+      value_type: double
+    enabled: true
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.queued_repair_time.avg:
+    description: Average time spent in warehouse queue waiting for compute resources to be repaired over the last 24 hour window.
+    unit: s 
+    gauge:
+      value_type: double
+    enabled: true
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.rows_inserted.avg:
+    description: Number of rows inserted into a table (or tables) over the last 24 hour window.
+    unit: "{rows}"
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.rows_deleted.avg:
+    description: Number of rows deleted from a table (or tables) over the last 24 hour window.
+    unit: "{rows}" 
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.rows_produced.avg:
+    description: Average number of rows produced by statement over the last 24 hour window.
+    unit: "{rows}" 
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.rows_unloaded.avg:
+    description: Average number of rows unloaded during data export over the last 24 hour window.
+    unit: "{rows}"
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.rows_updated.avg:
+    description: Average number of rows updated in a table over the last 24 hour window.
+    unit: "{rows}" 
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+  snowflake.total_elapsed_time.avg:
+    description: Average elapsed time over the last 24 hour window.
+    unit: s 
+    gauge:
+      value_type: double 
+    enabled: true 
+    attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
+
+  # Session metric 
+  snowflake.session_id.count:
+    description: Distinct session id's associated with snowflake username over the last 24 hour window.
+    unit: 1
+    gauge:
+      value_type: int
+    enabled: false
+    attributes: [user_name]
+  
+  # Snowpipe usage metrics
+  snowflake.pipe.credits_used.total:
+    description: Snow pipe credits contotaled over the last 24 hour window.
+    unit: "{credits}"
+    gauge:
+      value_type: double
+    enabled: false
+    attributes: [pipe_name]
+
+  # Storage usage metrics 
+  snowflake.storage.storage_bytes.total:
+    description: Number of bytes of table storage used, including bytes for data currently in Time Travel.
+    unit: By
+    gauge:
+      value_type: int
+    enabled: true
+  snowflake.storage.stage_bytes.total:
+    description: Number of bytes of stage storage used by files in all internal stages (named, table, user).
+    unit: By
+    gauge:
+      value_type: int
+    enabled: true
+  snowflake.storage.failsafe_bytes.total:
+    description: Number of bytes of data in Fail-safe.
+    unit: By
+    gauge:
+      value_type: int
+    enabled: false 

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/splunkenterprisereceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/splunkenterprisereceiver_metadata.yaml
@@ -1,0 +1,107 @@
+type: splunkenterprise
+
+status:
+  class: receiver
+  stability:
+    development: [metrics]
+  distributions:
+  codeowners:
+    active: [shalper2, MovieStoreGuy]
+
+attributes:
+  splunk.index.name:
+    description: The name of the index reporting a specific KPI
+    type: string
+  splunk.indexer.status:
+    description: The status message reported for a specific object
+    type: string
+  splunk.bucket.dir:
+    description: The bucket super-directory (home, cold, thawed) for each index
+    type: string
+  splunk.queue.name:
+    description: The name of the queue reporting a specific KPI
+    type: string  
+
+metrics:
+  splunk.license.index.usage:
+    enabled: true
+    description: Gauge tracking the indexed license usage per index
+    unit: By
+    gauge:
+      value_type: int 
+    attributes: [splunk.index.name]
+  # 'services/server/introspection/indexer'
+  splunk.indexer.throughput:
+    enabled: true
+    description: Gauge tracking average bytes per second throughput of indexer
+    unit: By/s
+    gauge:
+      value_type: double
+    # attribute `status` can be one of the following `normal`, `throttled`, `stopped`
+    attributes: [splunk.indexer.status]
+  # 'services/data/indexes-extended'
+  splunk.data.indexes.extended.total.size:
+    enabled: true
+    description: Size in bytes on disk of this index
+    unit: By
+    gauge:
+      value_type: int
+    attributes: [splunk.index.name]
+  splunk.data.indexes.extended.event.count:
+    enabled: true
+    description: Count of events for index, excluding frozen events. Approximately equal to the event_count sum of all buckets.
+    unit: '{events}'
+    gauge:
+      value_type: int
+    attributes: [splunk.index.name]
+  splunk.data.indexes.extended.bucket.count:
+    enabled: true
+    description: Count of buckets per index
+    unit: '{buckets}'
+    gauge:
+      value_type: int
+    attributes: [splunk.index.name]
+  splunk.data.indexes.extended.raw.size:
+    enabled: true
+    description: Size in bytes on disk of the <bucket>/rawdata/ directories of all buckets in this index, excluding frozen
+    unit: By
+    gauge:
+      value_type: int
+    attributes: [splunk.index.name]
+  ## Broken down `bucket_dirs`
+  splunk.data.indexes.extended.bucket.event.count:
+    enabled: false
+    description: Count of events in this bucket super-directory
+    unit: '{events}'
+    gauge:
+      value_type: int
+    attributes: [splunk.index.name, splunk.bucket.dir]
+  splunk.data.indexes.extended.bucket.hot.count:
+    enabled: false
+    description: (If size > 0) Number of hot buckets
+    unit: '{buckets}'
+    gauge:
+      value_type: int
+    attributes: [splunk.index.name, splunk.bucket.dir]
+  splunk.data.indexes.extended.bucket.warm.count:
+    enabled: false
+    description: (If size > 0) Number of warm buckets
+    unit: '{buckets}'
+    gauge:
+      value_type: int
+    attributes: [splunk.index.name, splunk.bucket.dir]  
+  #'services/server/introspection/queues' 
+  splunk.server.introspection.queues.current:
+    enabled: true
+    description: Gauge tracking current length of queue
+    unit: '{queues}'
+    gauge:
+      value_type: int
+    attributes: [splunk.queue.name]
+  splunk.server.introspection.queues.current.bytes:
+    enabled: true
+    description: Gauge tracking current bytes waiting in queue
+    unit: By
+    gauge:
+      value_type: int
+    attributes: [splunk.queue.name] 

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/sqlserverreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/sqlserverreceiver_metadata.yaml
@@ -1,0 +1,157 @@
+type: sqlserver
+
+status:
+  class: receiver
+  stability:
+    beta: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski, StefanKurek]
+
+resource_attributes:
+  sqlserver.database.name:
+    description: The name of the SQL Server database.
+    enabled: true
+    type: string
+  sqlserver.instance.name:
+    description: The name of the SQL Server instance being monitored.
+    enabled: false
+    type: string
+  sqlserver.computer.name:
+    description: The name of the SQL Server instance being monitored.
+    enabled: false
+    type: string
+
+attributes:
+  page.operations:
+    name_override: type
+    description: The page operation types.
+    type: string
+    enum: [read, write]
+
+metrics:
+  sqlserver.user.connection.count:
+    enabled: true
+    description: Number of users connected to the SQL Server.
+    unit: "{connections}"
+    gauge:
+      value_type: int
+  sqlserver.lock.wait_time.avg:
+    enabled: true
+    description: Average wait time for all lock requests that had to wait.
+    unit: ms
+    gauge:
+      value_type: double
+  sqlserver.lock.wait.rate:
+    enabled: true
+    description: Number of lock requests resulting in a wait.
+    unit: "{requests}/s"
+    gauge:
+      value_type: double
+  sqlserver.batch.request.rate:
+    enabled: true
+    description: Number of batch requests received by SQL Server.
+    unit: "{requests}/s"
+    gauge:
+      value_type: double
+  sqlserver.batch.sql_compilation.rate:
+    enabled: true
+    description: Number of SQL compilations needed.
+    unit: "{compilations}/s"
+    gauge:
+      value_type: double
+  sqlserver.batch.sql_recompilation.rate:
+    enabled: true
+    description: Number of SQL recompilations needed.
+    unit: "{compilations}/s"
+    gauge:
+      value_type: double
+  sqlserver.page.buffer_cache.hit_ratio:
+    enabled: true
+    description: Pages found in the buffer pool without having to read from disk.
+    unit: "%"
+    gauge:
+      value_type: double
+  sqlserver.page.life_expectancy:
+    enabled: true
+    description: Time a page will stay in the buffer pool.
+    unit: s
+    gauge:
+      value_type: int
+  sqlserver.page.split.rate:
+    enabled: true
+    description: Number of pages split as a result of overflowing index pages.
+    unit: "{pages}/s"
+    gauge:
+      value_type: double
+  sqlserver.page.lazy_write.rate:
+    enabled: true
+    description: Number of lazy writes moving dirty pages to disk.
+    unit: "{writes}/s"
+    gauge:
+      value_type: double
+  sqlserver.page.checkpoint.flush.rate:
+    enabled: true
+    description: Number of pages flushed by operations requiring dirty pages to be flushed.
+    unit: "{pages}/s"
+    gauge:
+      value_type: double
+  sqlserver.page.operation.rate:
+    enabled: true
+    description: Number of physical database page operations issued.
+    unit: "{operations}/s"
+    gauge:
+      value_type: double
+    attributes: [page.operations]
+  sqlserver.transaction_log.growth.count:
+    enabled: true
+    description: Total number of transaction log expansions for a database.
+    unit: "{growths}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+  sqlserver.transaction_log.shrink.count:
+    enabled: true
+    description: Total number of transaction log shrinks for a database.
+    unit: "{shrinks}"
+    sum:
+      monotonic: true
+      aggregation_temporality: cumulative
+      value_type: int
+  sqlserver.transaction_log.usage:
+    enabled: true
+    description: Percent of transaction log space used.
+    unit: "%"
+    gauge:
+      value_type: int
+  sqlserver.transaction_log.flush.wait.rate:
+    enabled: true
+    description: Number of commits waiting for a transaction log flush.
+    unit: "{commits}/s"
+    gauge:
+      value_type: double
+  sqlserver.transaction_log.flush.rate:
+    enabled: true
+    description: Number of log flushes.
+    unit: "{flushes}/s"
+    gauge:
+      value_type: double
+  sqlserver.transaction_log.flush.data.rate:
+    enabled: true
+    description: Total number of log bytes flushed.
+    unit: By/s
+    gauge:
+      value_type: double
+  sqlserver.transaction.rate:
+    enabled: true
+    description: Number of transactions started for the database (not including XTP-only transactions).
+    unit: "{transactions}/s"
+    gauge:
+      value_type: double
+  sqlserver.transaction.write.rate:
+    enabled: true
+    description: Number of transactions that wrote to the database and committed.
+    unit: "{transactions}/s"
+    gauge:
+      value_type: double

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/sshcheckreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/sshcheckreceiver_metadata.yaml
@@ -1,0 +1,67 @@
+type: sshcheck
+
+status:
+  class: receiver
+  stability:
+    alpha: [metrics]
+  distributions: [contrib, sumo]
+  codeowners:
+    active: [nslaughter, codeboten]
+
+resource_attributes:
+  ssh.endpoint:
+    description: Full SSH endpoint
+    type: string
+
+attributes:
+  error.message:
+    description: Error message recorded during check
+    type: string
+
+metrics:
+  sshcheck.status:
+    description: 1 if the SSH client successfully connected, otherwise 0.
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    unit: 1
+  sshcheck.duration:
+    description: Measures the duration of SSH connection.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: ms
+  sshcheck.error:
+    description: Records errors occurring during SSH check.
+    enabled: true
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    unit: "{error}"
+    attributes: [error.message]
+  sshcheck.sftp_status:
+    description: 1 if the SFTP server replied to request, otherwise 0.
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    unit: 1
+  sshcheck.sftp_duration:
+    description: Measures SFTP request duration.
+    enabled: false
+    gauge:
+      value_type: int
+    unit: ms
+  sshcheck.sftp_error:
+    description: Records errors occurring during SFTP check.
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    unit: "{error}"
+    attributes: [error.message]

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/vcenterreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/vcenterreceiver_metadata.yaml
@@ -1,0 +1,423 @@
+type: vcenter
+
+status:
+  class: receiver
+  stability:
+    alpha: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski, schmikei]
+
+resource_attributes:
+  vcenter.cluster.name:
+    description: The name of the vCenter Cluster.
+    enabled: true
+    type: string
+  vcenter.host.name:
+    description: The hostname of the vCenter ESXi host.
+    enabled: true
+    type: string
+  vcenter.resource_pool.name:
+    description: The name of the resource pool.
+    enabled: true
+    type: string
+  vcenter.resource_pool.inventory_path:
+    description: The inventory path of the resource pool.
+    enabled: true
+    type: string
+  vcenter.datastore.name:
+    description: The name of the vCenter datastore.
+    enabled: true
+    type: string
+  vcenter.vm.name:
+    description: The name of the virtual machine.
+    enabled: true
+    type: string
+  vcenter.vm.id:
+    description: The instance UUID of the virtual machine.
+    enabled: true
+    type: string
+
+attributes:
+  disk_state:
+    description: The state of storage and whether it is already allocated or free.
+    type: string
+    enum:
+      - available
+      - used
+  disk_type:
+    description: The type of storage device that is being recorded.
+    type: string
+    enum:
+      - virtual
+      - physical
+  host_effective:
+    type: bool
+    name_override: effective
+    description: Whether the host is effective in the vCenter cluster.
+  disk_direction:
+    name_override: direction
+    description: The direction of disk latency.
+    type: string
+    enum:
+      - read
+      - write
+  throughput_direction:
+    name_override: direction
+    description: The direction of network throughput.
+    type: string
+    enum:
+      - transmitted
+      - received
+  vm_count_power_state:
+    name_override: power_state
+    description: Whether the virtual machines are powered on or off.
+    type: string
+    enum:
+      - "on"
+      - "off"
+  object_name:
+    name_override: object
+    description: The object on the virtual machine or host that is being reported on.
+    type: string
+
+metrics:
+  vcenter.cluster.cpu.limit:
+    enabled: true
+    description: The amount of CPU available to the cluster.
+    unit: "{MHz}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.cluster.cpu.effective:
+    enabled: true
+    description: The effective CPU available to the cluster. This value excludes CPU from hosts in maintenance mode or are unresponsive.
+    unit: "{MHz}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.cluster.memory.limit:
+    enabled: true
+    description: The available memory of the cluster.
+    unit: By
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.cluster.memory.effective:
+    enabled: true
+    description: The effective memory of the cluster. This value excludes memory from hosts in maintenance mode or are unresponsive.
+    unit: By
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.cluster.memory.used:
+    enabled: true
+    description: The memory that is currently used by the cluster.
+    unit: By
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.cluster.vm.count:
+    enabled: true
+    description: the number of virtual machines in the cluster.
+    unit: "{virtual_machines}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [vm_count_power_state]
+  vcenter.cluster.host.count:
+    enabled: true
+    description: The number of hosts in the cluster.
+    unit: "{hosts}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [host_effective]
+  vcenter.datastore.disk.usage:
+    enabled: true
+    description: The amount of space in the datastore.
+    unit: By
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [disk_state]
+  vcenter.datastore.disk.utilization:
+    enabled: true
+    description: The utilization of the datastore.
+    unit: "%"
+    gauge:
+      value_type: double
+    attributes: []
+  vcenter.host.cpu.utilization:
+    enabled: true
+    description: The CPU utilization of the host system.
+    unit: "%"
+    gauge:
+      value_type: double
+    attributes: []
+  vcenter.host.cpu.usage:
+    enabled: true
+    description: The amount of CPU used by the host.
+    unit: "MHz"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.host.disk.throughput:
+    enabled: true
+    description: Average number of kilobytes read from or written to the disk each second.
+    unit: "{KiBy/s}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [disk_direction, object_name]
+    extended_documentation: As measured over the most recent 20s interval. Aggregated disk I/O rate. Requires Performance Level 4.
+  vcenter.host.disk.latency.avg:
+    enabled: true
+    description: The latency of operations to the host system's disk.
+    unit: ms
+    gauge:
+      value_type: int
+    attributes: [disk_direction, object_name]
+    extended_documentation: This latency is the sum of the device and kernel read and write latencies. Requires Performance Counter level 2 for metric to populate.
+  vcenter.host.disk.latency.max:
+    enabled: true
+    description: Highest latency value across all disks used by the host.
+    unit: ms
+    gauge:
+      value_type: int
+    attributes: [object_name]
+    extended_documentation: As measured over the most recent 20s interval. Requires Performance Level 3.
+  vcenter.host.memory.utilization:
+    enabled: true
+    description: The percentage of the host system's memory capacity that is being utilized.
+    unit: "%"
+    gauge:
+      value_type: double
+    attributes: []
+  vcenter.host.memory.usage:
+    enabled: true
+    description: The amount of memory the host system is using.
+    unit: MiBy
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.host.network.throughput:
+    enabled: true
+    description: The amount of data that was transmitted or received over the network by the host.
+    unit: "{KiBy/s}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [throughput_direction, object_name]
+    extended_documentation: As measured over the most recent 20s interval.
+  vcenter.host.network.usage:
+    enabled: true
+    description: The sum of the data transmitted and received for all the NIC instances of the host.
+    unit: "{KiBy/s}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [object_name]
+  vcenter.host.network.packet.errors:
+    enabled: true
+    description: The summation of packet errors on the host network.
+    unit: "{errors}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [throughput_direction, object_name]
+    extended_documentation: As measured over the most recent 20s interval.
+  vcenter.host.network.packet.count:
+    enabled: true
+    description: The number of packets transmitted and received, as measured over the most recent 20s interval.
+    unit: "{packets/sec}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [throughput_direction, object_name]
+  vcenter.resource_pool.memory.usage:
+    enabled: true
+    description: The usage of the memory by the resource pool.
+    unit: MiBy
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.resource_pool.memory.shares:
+    enabled: true
+    description: The amount of shares of memory in the resource pool.
+    unit: "{shares}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.resource_pool.cpu.usage:
+    enabled: true
+    description: The usage of the CPU used by the resource pool.
+    unit: "{MHz}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.resource_pool.cpu.shares:
+    enabled: true
+    description: The amount of shares of CPU in the resource pool.
+    unit: "{shares}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.vm.memory.ballooned:
+    enabled: true
+    description: The amount of memory that is ballooned due to virtualization.
+    unit: MiBy
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.vm.memory.usage:
+    enabled: true
+    description: The amount of memory that is used by the virtual machine.
+    unit: MiBy
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.vm.memory.swapped:
+    enabled: true
+    description: The portion of memory that is granted to this VM from the host's swap space.
+    unit: MiBy
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.vm.memory.swapped_ssd:
+    enabled: true
+    description: The amount of memory swapped to fast disk device such as SSD.
+    unit: KiBy
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.vm.disk.usage:
+    enabled: true
+    description: The amount of storage space used by the virtual machine.
+    unit: By
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [disk_state]
+  vcenter.vm.disk.utilization:
+    enabled: true
+    description: The utilization of storage on the virtual machine.
+    unit: "%"
+    gauge:
+      value_type: double
+    attributes: []
+  vcenter.vm.disk.latency.avg:
+    enabled: true
+    description: The latency of operations to the virtual machine's disk.
+    unit: ms
+    gauge:
+      value_type: int
+    attributes: [disk_direction, disk_type, object_name]
+    extended_documentation: Requires Performance Counter level 2 for metric to populate. As measured over the most recent 20s interval.
+  vcenter.vm.disk.latency.max:
+    enabled: true
+    description: The highest reported total latency (device and kernel times) over an interval of 20 seconds.
+    unit: ms
+    gauge:
+      value_type: int
+    attributes: [object_name]
+  vcenter.vm.disk.throughput:
+    enabled: true
+    description: The throughput of the virtual machine's disk.
+    unit: By/sec
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [object_name]
+  vcenter.vm.network.throughput:
+    enabled: true
+    description: The amount of data that was transmitted or received over the network of the virtual machine.
+    unit: By/sec
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [throughput_direction, object_name]
+    extended_documentation: As measured over the most recent 20s interval.
+  vcenter.vm.network.packet.count:
+    enabled: true
+    description: The amount of packets that was received or transmitted over the instance's network.
+    unit: "{packets/sec}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [throughput_direction, object_name]
+  vcenter.vm.network.usage:
+    enabled: true
+    description: The network utilization combined transmit and receive rates during an interval.
+    unit: "{KiBy/s}"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: [object_name]
+    extended_documentation: As measured over the most recent 20s interval.
+  vcenter.vm.cpu.utilization:
+    enabled: true
+    description: The CPU utilization of the VM.
+    unit: "%"
+    gauge:
+      value_type: double
+    attributes: []
+  vcenter.vm.cpu.usage:
+    enabled: true
+    description: The amount of CPU used by the VM.
+    unit: "MHz"
+    sum:
+      monotonic: false
+      value_type: int
+      aggregation_temporality: cumulative
+    attributes: []
+  vcenter.vm.memory.utilization:
+    enabled: false
+    description: The memory utilization of the VM.
+    unit: "%"
+    gauge:
+      value_type: double
+    attributes: []

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/zookeeperreceiver_metadata.yaml
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/otel-receiver-yaml/zookeeperreceiver_metadata.yaml
@@ -1,0 +1,155 @@
+type: zookeeper
+
+status:
+  class: receiver
+  stability:
+    development: [metrics]
+  distributions: [contrib, observiq, sumo]
+  codeowners:
+    active: [djaglowski]
+
+resource_attributes:
+  server.state:
+    description: State of the Zookeeper server (leader, standalone or follower).
+    enabled: true
+    type: string
+  zk.version:
+    description: Zookeeper version of the instance.
+    enabled: true
+    type: string
+
+attributes:
+  state:
+    description: State of followers
+    type: string
+    enum:
+      - synced
+      - unsynced
+  direction:
+    description: State of a packet based on io direction.
+    type: string
+    enum:
+      - received
+      - sent
+
+metrics:
+  zookeeper.follower.count:
+    enabled: true
+    description: The number of followers. Only exposed by the leader.
+    unit: "{followers}"
+    attributes: [state]
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+  zookeeper.sync.pending:
+    enabled: true
+    description: The number of pending syncs from the followers. Only exposed by the leader.
+    unit: "{syncs}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+  zookeeper.latency.avg:
+    enabled: true
+    description: Average time in milliseconds for requests to be processed.
+    unit: ms
+    gauge:
+      value_type: int
+  zookeeper.latency.max:
+    enabled: true
+    description: Maximum time in milliseconds for requests to be processed.
+    unit: ms
+    gauge:
+      value_type: int
+  zookeeper.latency.min:
+    enabled: true
+    description: Minimum time in milliseconds for requests to be processed.
+    unit: ms
+    gauge:
+      value_type: int
+  zookeeper.connection.active:
+    enabled: true
+    description: Number of active clients connected to a ZooKeeper server.
+    unit: "{connections}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+  zookeeper.request.active:
+    enabled: true
+    description: Number of currently executing requests.
+    unit: "{requests}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+  zookeeper.znode.count:
+    enabled: true
+    description: Number of z-nodes that a ZooKeeper server has in its data tree.
+    unit: "{znodes}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+  zookeeper.watch.count:
+    enabled: true
+    description: Number of watches placed on Z-Nodes on a ZooKeeper server.
+    unit: "{watches}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+  zookeeper.data_tree.ephemeral_node.count:
+    enabled: true
+    description: Number of ephemeral nodes that a ZooKeeper server has in its data tree.
+    unit: "{nodes}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+  zookeeper.data_tree.size:
+    enabled: true
+    description: Size of data in bytes that a ZooKeeper server has in its data tree.
+    unit: By
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+  zookeeper.file_descriptor.open:
+    enabled: true
+    description: Number of file descriptors that a ZooKeeper server has open.
+    unit: "{file_descriptors}"
+    sum:
+      monotonic: false
+      aggregation_temporality: cumulative
+      value_type: int
+  zookeeper.file_descriptor.limit:
+    enabled: true
+    description: Maximum number of file descriptors that a ZooKeeper server can open.
+    unit: "{file_descriptors}"
+    gauge:
+      value_type: int
+  zookeeper.packet.count:
+    enabled: true
+    description: The number of ZooKeeper packets received or sent by a server.
+    unit: "{packets}"
+    attributes: [direction]
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  zookeeper.fsync.exceeded_threshold.count:
+    enabled: true
+    description: Number of times fsync duration has exceeded warning threshold.
+    unit: "{events}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  zookeeper.ruok:
+    enabled: true
+    description: Response from zookeeper ruok command
+    unit: 1
+    gauge:
+      value_type: int

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/pull-otel-yaml.py
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/pull-otel-yaml.py
@@ -1,0 +1,59 @@
+import os
+import requests
+import yaml
+
+# GitHub repository information
+repo_owner = "open-telemetry"
+repo_name = "opentelemetry-collector-contrib"
+repo_path = "receiver"
+github_token = os.environ.get('GITHUB_PAT_TOKEN')
+headers = {}
+api_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/contents/{repo_path}"
+
+# Check for our PAT and make auth headers so we don't get rate limited
+if github_token is not None:
+    headers["Authorization"] = "Bearer " + github_token
+else:
+    print("no $GITHUB_PAT_TOKEN environment variable found. Expect rate limiting.")
+
+# Make a request to GitHub API
+response = requests.get(api_url, headers=headers)
+contents = response.json()
+if response.status_code != 200:
+    print("Received " + str(response.status_code) + " STATUS CODE. \n" + response.text)
+    exit()
+
+# Iterate through contents and find subdirectories
+directories = [content["name"] for content in contents if content["type"] == "dir"]
+
+# Iterate through subdirectories and extract metadata.yaml with 'metrics' section
+for sub in directories:
+    subdir_api_url = f"{api_url}/{sub}"
+    subdir_response = requests.get(subdir_api_url, headers=headers)
+    if subdir_response.status_code != 200:
+        print("Received " + str(subdir_response.status_code) + " STATUS CODE. \n" + response.text)
+        exit()
+    subdir_contents = subdir_response.json()
+
+    # Check if metadata.yaml exists in the subdirectory
+    metadata_content = None
+    for content in subdir_contents:
+        if content["name"] == "metadata.yaml":
+            metadata_url = content["download_url"]
+            metadata_response = requests.get(metadata_url, headers=headers)
+            if metadata_response.status_code != 200:
+                print("Received " + str(metadata_response.status_code) + " STATUS CODE. \n" + response.text)
+                exit()
+            metadata_content = metadata_response.text
+            break
+
+    if metadata_content:
+        # Parse YAML content
+        metadata_data = yaml.safe_load(metadata_content)
+
+        # Check if 'metrics' section exists in metadata.yaml then save
+        if "metrics" in metadata_data:
+            filename = f"./otel-receiver-yaml/{sub}_metadata.yaml"
+            with open(filename, "w") as file:
+                file.write(metadata_content)
+            print(f"Metadata.yaml with 'metrics' section extracted from {sub}")

--- a/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/requirements.txt
+++ b/dashboards-and-dashboard-groups/otel-receiver-dashboard-generator/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML==6.*
+Requests==2.*


### PR DESCRIPTION
Python script for taking the metrics named in any given OpenTelemetry Receiver's `metadata.yaml` and create a dashboard for Splunk Observability with those metrics as a Terraform config. Saves time for users who need/want to use a contrib receiver but don't want to hunt down all the possible metrics and add them to a dashboard.

- Included a folder of generated dashboards as well (`observability-tf-configs`)
- `otel-receiver-yaml` directory contains current yaml files for receivers. Can also be pulled down by script.

**NOTE:** These dashboards are GENERATED and are NOT a replacement for Out Of The Box dashboard/content in Splunk Observability. This is also noted in the README.md.